### PR TITLE
feat/abort-image-fetches

### DIFF
--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -3,6 +3,7 @@ import NetworkContextProvider from '@/pages/lib/NetworkContext';
 import ProductContextProvider from '@/pages/lib/ProductContext';
 import PrevProductContextProvider from '@/pages/lib/PrevProductContext';
 import UserContextProvider from '@/pages/lib/UserContext';
+import AbortControllerContextProvider from '@/pages/lib/AbortControllerContext';
 import { theme } from '@/pages/lib/utils';
 import '@/styles/globals.css';
 import { ThemeProvider } from '@mui/material';
@@ -15,21 +16,23 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider theme={theme}>
       <NetworkContextProvider>
-        <UserContextProvider>
-          <CategoryContextProvider>
-            <ProductContextProvider>
-              <PrevProductContextProvider>
-                <NextIntlClientProvider
-                  locale={router.locale}
-                  timeZone="Asia/Ashgabat"
-                  messages={pageProps.messages}
-                >
-                  <Component {...pageProps} />
-                </NextIntlClientProvider>
-              </PrevProductContextProvider>
-            </ProductContextProvider>
-          </CategoryContextProvider>
-        </UserContextProvider>
+        <AbortControllerContextProvider>
+          <UserContextProvider>
+            <CategoryContextProvider>
+              <ProductContextProvider>
+                <PrevProductContextProvider>
+                  <NextIntlClientProvider
+                    locale={router.locale}
+                    timeZone="Asia/Ashgabat"
+                    messages={pageProps.messages}
+                  >
+                    <Component {...pageProps} />
+                  </NextIntlClientProvider>
+                </PrevProductContextProvider>
+              </ProductContextProvider>
+            </CategoryContextProvider>
+          </UserContextProvider>
+        </AbortControllerContextProvider>
       </NetworkContextProvider>
     </ThemeProvider>
   );

--- a/src/pages/components/ProductCard.tsx
+++ b/src/pages/components/ProductCard.tsx
@@ -42,15 +42,24 @@ export default function ProductCard({
   const theme = useTheme();
   const isMdUp = useMediaQuery(theme.breakpoints.up('md'));
   const { network } = useNetworkContext();
+  // I was trying to abo fetches here:
+  // const [abortControllers, setAbortControllers] = useState<AbortController[]>([]);
 
   useEffect(() => {
     (async () => {
+      // (uncomment) I was trying to abort fetches:
+      // const abortController = new AbortController;
+      // console.log('abort: ', abortController);
+      // setAbortControllers((prevAbortControllers: AbortController[]) => [...prevAbortControllers, abortController]);
+
       if (product?.imgUrls[0] != null && network !== 'unknown') {
         setImgUrl('/xmobile-original-logo.jpeg');
         if (product.imgUrls[0].startsWith('http')) {
           setImgUrl(product.imgUrls[0]);
         } else {
           const imgFetcher = fetch(
+            // (uncomment) I was trying to abort fetches:
+            // `${BASE_URL}/api/localImage?imgUrl=${product.imgUrls[0]}&network=${network}&quality=bad`, {signal: abortController.signal}
             `${BASE_URL}/api/localImage?imgUrl=${product.imgUrls[0]}&network=${network}&quality=bad`,
           );
           const resp = await imgFetcher;
@@ -61,6 +70,19 @@ export default function ProductCard({
       }
     })();
   }, [product?.imgUrls, network]);
+
+  // (uncomment) I was trying to abort fetches:
+  // useCallback(()=>{
+  // const handleAbort = () => {
+  //   // console.log('abort called');
+
+  //   abortControllers.map((abortController) => {
+  //     abortController.abort;
+  //     console.log('fetch aborted');
+  //   })
+  // }
+  // router.events.on('routeChangeStart', handleAbort);
+  // }, [router.events])
 
   useEffect(() => {
     if (initialProduct == null) return;

--- a/src/pages/lib/AbortControllerContext.tsx
+++ b/src/pages/lib/AbortControllerContext.tsx
@@ -1,0 +1,77 @@
+import { AbortControllerContextProp } from '@/pages/lib/types';
+import { useRouter } from 'next/router';
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useCallback,
+} from 'react';
+
+const AbortControllerContext = createContext<AbortControllerContextProp>({
+  abortControllersRef: { current: new Set() },
+  createAbortController: () => undefined,
+  clearAbortController: () => undefined,
+  clearAllAborts: () => undefined,
+});
+
+export const useAbortControllerContext = () =>
+  useContext(AbortControllerContext);
+
+export default function AbortControllerContextProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const router = useRouter();
+  const abortControllersRef = useRef<Set<AbortController>>(new Set());
+
+  const createAbortController = useCallback(() => {
+    const controller = new AbortController();
+    abortControllersRef.current.add(controller);
+
+    return controller;
+  }, []);
+
+  const clearAllAborts = useCallback(() => {
+    abortControllersRef.current.forEach((controller) => {
+      if (!controller.signal.aborted) {
+        controller.abort();
+      }
+    });
+    abortControllersRef.current.clear();
+  }, []);
+
+  const clearAbortController = useCallback((controller: AbortController) => {
+    abortControllersRef.current.delete(controller);
+  }, []);
+
+  useEffect(() => {
+    const handleRouteChange = () => {
+      clearAllAborts();
+    };
+    router.events.on('routeChangeStart', handleRouteChange);
+
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChange);
+    };
+  }, [router.events, clearAllAborts]);
+
+  const value = useMemo(
+    () => ({
+      abortControllersRef,
+      createAbortController,
+      clearAllAborts,
+      clearAbortController,
+    }),
+    [createAbortController, clearAllAborts, clearAbortController],
+  );
+
+  return (
+    <AbortControllerContext.Provider value={value}>
+      {children}
+    </AbortControllerContext.Provider>
+  );
+}

--- a/src/pages/lib/types.ts
+++ b/src/pages/lib/types.ts
@@ -107,6 +107,13 @@ export interface NetworkContextProps {
   setNetwork: Dispatch<SetStateAction<NetworkType>>;
 }
 
+export interface AbortControllerContextProp {
+  abortControllersRef: React.MutableRefObject<Set<AbortController>>;
+  createAbortController: () => AbortController;
+  clearAbortController: (controller: AbortController) => void;
+  clearAllAborts: () => void;
+}
+
 export interface CategoryName {
   en: string;
   ru: string;


### PR DESCRIPTION
### Description:
**Reason:**
- The page wasn't redirecting to new page unless all the fetches on the current page got resolved

**Solution**:
- created a AbortControllerContext, than cancels ongoing fetches on route change (i.e doesn't wait until they get resolved)
- passes abortController's signal to image fetches in detail.page.tsx and product.page 

closes #57 