### PR TITLE
fix/bread-crumb-issue

### DIFF
--- a/src/pages/components/Appbar.tsx
+++ b/src/pages/components/Appbar.tsx
@@ -209,7 +209,8 @@ export default function CustomAppBar({
             <Box
               sx={{
                 width: { xs: 100, sm: 120 },
-                height: { xs: 100, sm: 120 },
+                height: '100%',
+                // height: { xs: 100, sm: 120 },
               }}
               className="flex items-center justify-center"
               onClick={() => {

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -182,6 +182,15 @@ export default function Home({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allCategories]);
 
+  // Clicking the xmobile-logo from the index page doesn't update localCategories
+  // because xmobile-logo is on appbar.tsx and it only clears `stack`.
+  // This effect resets localCategories when stack becomes empty.
+  useEffect(() => {
+    if (stack.length === 0) {
+      setLocalCategories(allCategories);
+    }
+  }, [stack]);
+
   return (
     <Layout
       handleHeaderBackButton={


### PR DESCRIPTION
### Description:
**Issue**:
- Xmobile logo's height was covering breadcrumbs, making clickable latest breadcrumb and redirecting to main page
- When clicking logo from index page after entering some category, it wasn't redirecting to the main page (i.e to the page where only head categories are shown: index page). 

**Fixes**:
- adjusted logo height to appbar
- update localCategories when stack gets empty (i.e when xmobile logo pressed from index page)

closes #64 