### PR TITLE
copy prod data to local

### DIFF
--- a/scripts/update-db-img-urls.sh
+++ b/scripts/update-db-img-urls.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-source .env.local
+CURRENT_DIR=$(dirname "$(realpath "$0")")
+
+# convert to windows-style path if on windows
+if [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
+  CURRENT_DIR=$(cygpath -w "$CURRENT_DIR")
+fi
+source "$CURRENT_DIR/../.env.local"
 
 if [ -z "$DATABASE_URL" ]; then
   echo "DATABASE_URL is not set in the environment."
@@ -8,7 +14,6 @@ if [ -z "$DATABASE_URL" ]; then
 fi
 
 DATABASE_URL=${DATABASE_URL%\?schema=public}
-CURRENT_DIR=$(pwd)
 
 psql "$DATABASE_URL" <<EOF
 UPDATE "Category"


### PR DESCRIPTION
This PR has been closed as it is no longer needed. It was originally intended to handle Windows path differences when updating image sources in the local DB after copying production data.

This flow is now discontinued. The current process is to run `backup-production-data.sh` and `apply-backup.sh`. Even if run on Windows, using Bash (instead of PowerShell) works correctly