### PR TITLE
fix/cart

### DIFF
--- a/src/pages/components/AddToCart.tsx
+++ b/src/pages/components/AddToCart.tsx
@@ -281,7 +281,7 @@ export default function AddToCart({
         >
           {snackbarMessage?.message && t(snackbarMessage.message)}
           {snackbarMessage?.message === 'userNotFound' && (
-            <Link href="user/signin">
+            <Link href="/user/signin">
               {`. ${t('signin')}`}
               <LoginIcon />
             </Link>


### PR DESCRIPTION
**Description**:
Issue #101:
- redirection to `signin page` was **relative**, so path became `product/user/signin` which doesn't exist

**Fixed**:
- now redirection to `signing page` is **absolute**, so path is `user/signin` always.

closes #101 