### PR TITLE
fix/build-script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,7 +16,7 @@ main() {
             git clone git@github.com:xmobile-atamyrat/xmobile-v1.git /app/xmobile-v1 && \
             cd /app/xmobile-v1 && \
             rm -rf .env.local && \
-            yarn cache clean && yarn install --force && \
+            yarn cache clean && yarn install --force --network-timeout 600000 && \
             tar -czvf /app/xmobile-v1.tar.gz /app/xmobile-v1
         '
         docker cp build_env:/app/xmobile-v1.tar.gz .


### PR DESCRIPTION
Issue:
```
[2/5] Resolving packages...
[3/5] Fetching packages...
info There appears to be trouble with your network connection. Retrying...
```
- `yarn install` times out while building inside docker 

Fix:
- increasing default `30s timeout` to `5-10min` helps to fix this issue