### PR TITLE
fix/deployment

### DIFF
--- a/scripts/prod_scripts/update-server-source.sh
+++ b/scripts/prod_scripts/update-server-source.sh
@@ -49,6 +49,9 @@ echo "Copying 'tsconfig.json' & 'tsconfig.ws.json'"
 mv /home/ubuntu/tar-file/app/xmobile-v1/tsconfig.json .
 mv /home/ubuntu/tar-file/app/xmobile-v1/tsconfig.ws.json .
 
+echo "Copying 'tailwind.config.ts'"
+mv /home/ubuntu/tar-file/app/xmobile-v1/tailwind.config.ts .
+
 rm -rf .next
 yarn build
 yarn build:ws


### PR DESCRIPTION
- copy tailwind config to the production

#### Reason
- on the server, tailwind's configuration wasn't picking up the new style instructions in the `src/styles/` folder