### PR TITLE
build prod on amd64 ubuntu image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM --platform=linux/amd64 ubuntu:latest
 
 WORKDIR /app
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,7 +6,7 @@ main() {
     if [[ -z "$SSH_PASSPHRASE" ]]; then
         echo "Skipping docker operations. Provide SSH_PASSPHRASE as the first argument to run docker operations"
     else
-        docker-compose up -d build_env
+        docker-compose up -d --build build_env
         docker exec build_env sh -c '[ -d /app/xmobile-v1 ] && rm -rf /app/xmobile-v1 && [ -f /app/xmobile-v1.tar.gz ] && rm -f /app/xmobile-v1.tar.gz'
         docker exec -e SSH_PASSPHRASE="$SSH_PASSPHRASE" build_env sh -c '
             eval $(ssh-agent -s) && \


### PR DESCRIPTION
Docker pulls image corresponding to the host machine's architecture. I forgot to provide platform in Dockerfile so it was using arm64 architecture ubuntu because mac m1 is arm64. But the ubuntu machine on telekom is amd64 architecture. 

Windows is also amd64 which is why @Babahan-0906 builds were deploying properly but mine were failing. It started failing recently because all the packages we were using before `sharp` were compatible for both architectures. `sharp` was installing native architecture version.