### PR TITLE
Removed the name length limit on prodCards

### DIFF
--- a/src/pages/components/ProductCard.tsx
+++ b/src/pages/components/ProductCard.tsx
@@ -128,7 +128,7 @@ export default function ProductCard({
               gutterBottom
               className={`${interClassname.className} ${productCardClasses.typo[platform]}`}
             >
-              {parseName(product.name, router.locale ?? 'tk').substring(0, 24)}
+              {parseName(product.name, router.locale ?? 'tk')}
             </Typography>
             {product?.price?.includes('[') ? (
               <CircularProgress


### PR DESCRIPTION
I checked if prod names are too long for prod cards on my end, but suggested to test for any cases