### PR TITLE
fix websocket connection issue

### DIFF
--- a/src/pages/lib/ChatContext.tsx
+++ b/src/pages/lib/ChatContext.tsx
@@ -212,7 +212,7 @@ export const ChatContextProvider = ({ children }: { children: ReactNode }) => {
 
     const wsBase =
       process.env.NODE_ENV === 'production'
-        ? `wss://${process.env.NEXT_PUBLIC_HOST}`
+        ? `wss://xmobile.com.tm`
         : `ws://localhost:${process.env.NEXT_PUBLIC_WEBSOCKET_PORT}`;
     const wsUrl = `${wsBase}/ws/?accessToken=${accessToken}`;
     ws.current = new WebSocket(wsUrl);


### PR DESCRIPTION
When the browser connects to wss://216.250.13.115:
- It performs the TLS handshake
- Receives the SSL certificate (issued for xmobile.com.tm)
- Validates that the certificate matches the hostname in the URL
- Fails because the certificate is for xmobile.com.tm but the URL uses 216.250.13.115
- Rejects the connection before it reaches nginx

This explains:
- No nginx logs: the connection fails at the TLS handshake
- Postman works: it can ignore certificate validation
- Browser fails: browsers enforce certificate validation