### PR TITLE
render high quality image when viewing product in enlarged mode

### DIFF
--- a/src/pages/product/[id].page.tsx
+++ b/src/pages/product/[id].page.tsx
@@ -157,14 +157,57 @@ export default function Product({ product: initialProduct }: ProductPageProps) {
   const platform = usePlatform();
   const [dialogStatus, setDialogStatus] = useState(false);
   const [carouselDialogImage, setCarouselDialogImage] = useState<string>('');
+  const [carouselDialogImageUrl, setCarouselDialogImageUrl] =
+    useState<string>('');
+
+  const cleanupObjectUrl = (url: string) => {
+    if (url && url.startsWith('blob:')) {
+      URL.revokeObjectURL(url);
+    }
+  };
 
   const handleDialogClose = () => {
     setDialogStatus(false);
+    cleanupObjectUrl(carouselDialogImageUrl);
+    setCarouselDialogImageUrl('');
   };
 
-  const handleDialogOpen = (imgUrl: string) => {
+  const handleDialogOpen = async (imgUrl: string, originalImgUrl: string) => {
     setDialogStatus(true);
     setCarouselDialogImage(imgUrl);
+
+    try {
+      if (!originalImgUrl) {
+        throw new Error('Invalid image URL: URL is empty');
+      }
+
+      // Fetch high-quality version for enlarged view
+      // Only fetch from API if it's a local image (not an external URL)
+      if (
+        originalImgUrl &&
+        !originalImgUrl.startsWith('http://') &&
+        !originalImgUrl.startsWith('https://') &&
+        !originalImgUrl.startsWith('blob:')
+      ) {
+        const response = await fetch(
+          `${BASE_URL}/api/localImage?imgUrl=${encodeURIComponent(originalImgUrl)}&network=fast`,
+        );
+
+        if (!response.ok) {
+          throw new Error(
+            `Failed to fetch high-quality image: ${response.status}`,
+          );
+        }
+
+        const highQualityBlob = await response.blob();
+        cleanupObjectUrl(carouselDialogImageUrl);
+        const highQualityUrl = URL.createObjectURL(highQualityBlob);
+        setCarouselDialogImageUrl(highQualityUrl);
+        setCarouselDialogImage(highQualityUrl);
+      }
+    } catch (error) {
+      console.error('Failed to load high-quality image:', error);
+    }
   };
 
   // Get categoryId from query params
@@ -336,7 +379,7 @@ export default function Product({ product: initialProduct }: ProductPageProps) {
                 image={imgUrls[0]}
                 alt={product?.name}
                 className={detailPageClasses.cardMedia[platform]}
-                onClick={() => handleDialogOpen(imgUrls[0])}
+                onClick={() => handleDialogOpen(imgUrls[0], product.imgUrls[0])}
               />
             </Box>
           )}
@@ -350,7 +393,9 @@ export default function Product({ product: initialProduct }: ProductPageProps) {
                     alt={product?.name}
                     className={detailPageClasses.cardMedia[platform]}
                     key={index}
-                    onClick={() => handleDialogOpen(imgUrl)}
+                    onClick={() =>
+                      handleDialogOpen(imgUrl, product.imgUrls[index])
+                    }
                   />
                 ))}
               </Carousel>


### PR DESCRIPTION
Enlarged product photos were displaying the same network-adaptive compressed quality as thumbnails, resulting in poor quality on slow connections.

## Changes

Modified `/src/pages/product/[id].page.tsx` to fetch high-quality images when dialog opens:

- **Progressive loading**: Dialog opens immediately with current quality, then upgrades to `network=fast` ('good' compression: 150KB, original width)
- **Memory management**: Added blob URL tracking and cleanup via `URL.revokeObjectURL()` 
- **Validation**: URL encoding, empty check, response status verification, explicit protocol detection (`http://`, `https://`, `blob:`)

External URLs bypass re-fetching. Graceful fallback on fetch failure.

Closes #235 