### PR TITLE
Increase CD timeout limit

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -37,7 +37,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: resolve
     outputs:
       short_sha: ${{ needs.resolve.outputs.short_sha }}
@@ -148,7 +148,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: build
     steps:
       - name: Setup SSH key and config

--- a/.github/workflows/deploy-healthcheck.yml
+++ b/.github/workflows/deploy-healthcheck.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## What
Increase timeout minutes for **build** and **deployment** steps.

## Why
In one deployment job, the NextJS build ran for around ~4 minutes and failed due to the timeout limit:  
[https://github.com/xmobile-atamyrat/xmobile-v1/actions/runs/22717488181/job/65870768710](https://github.com/xmobile-atamyrat/xmobile-v1/actions/runs/22717488181/job/65870768710)

The decision was made to increase the timeout limit.