### PR TITLE
hotfix/cd

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -37,7 +37,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     needs: resolve
     outputs:
       short_sha: ${{ needs.resolve.outputs.short_sha }}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,11 @@ const nextConfig = {
     defaultLocale: 'ru',
     localeDetection: false,
   },
+  experimental: {
+    workerThreads: false,
+    cpus: 2,
+  },
+  staticPageGenerationTimeout: 180
 };
 
 export default nextConfig;


### PR DESCRIPTION
- increase build timeout in GitHub workflows
- increase static page generation timeout
- limit Next.js static page generation to 2 CPUs

## why
- the `build & deploy` workflow failed [(↗)](https://github.com/xmobile-atamyrat/xmobile-v1/actions/runs/22793583367) because Next.js hit its 60-second hard limit while generating static pages, especially for `category/[id]`
- the assumed cause is that Next.js spawns multiple workers for static page generation
- each worker makes 2 database calls, which likely exhausts CPU resources on the GitHub Actions runner machine
