### PR TITLE
rollback/next-config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,10 +9,6 @@ const nextConfig = {
     defaultLocale: 'ru',
     localeDetection: false,
   },
-  experimental: {
-    workerThreads: false,
-    cpus: 2,
-  },
   staticPageGenerationTimeout: 180
 };
 


### PR DESCRIPTION
## what
- rollback next js config's cpu and worker params
- kept 3 minute static page generation timeout limit

## why
-  monitor if the static page generation timeout limit occurs 