### PR TITLE
rename fcm to fcm-configs in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,5 @@ db_backup.sql
 backup/
 backup-data.sh
 ssl_keys
-fcm
+fcm-configs
 google-services.json


### PR DESCRIPTION
We have ts files under `fcm/` dir. We should keep fcm related config/secret files in `fcm-configs` dir.