### PR TITLE
Prevent the same fcm token hitting create

### DIFF
--- a/src/pages/api/fcm/token.page.ts
+++ b/src/pages/api/fcm/token.page.ts
@@ -80,19 +80,20 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseApi>) {
             message: 'Token already registered to another user',
           });
         }
-        // Scenario 2.b: Token exists, DeviceInfo doesn't exist, User matches → CREATE
-        // This is valid - user is adding a new device with an existing token
-        // (unlikely but possible if token was reused)
+        // Scenario 2.b: Token exists, DeviceInfo doesn't exist, User matches → already registered
+        // The token is valid and belongs to this user, nothing to do.
+        return res.status(200).json({
+          success: true,
+          message: 'Token already registered',
+        });
       }
 
       // SCENARIO 3: Token doesn't exist, DeviceInfo doesn't exist → CREATE
-      // Create new token record (first-time registration)
-      await dbClient.fCMToken.create({
-        data: {
-          userId,
-          token,
-          deviceInfo,
-        },
+      // Use upsert on token to safely handle concurrent requests (TOCTOU race condition)
+      await dbClient.fCMToken.upsert({
+        where: { token },
+        update: { deviceInfo, userId },
+        create: { userId, token, deviceInfo },
       });
 
       return res.status(201).json({


### PR DESCRIPTION
This PR addresses a PrismaClientKnownRequestError (Unique constraint failed) occurring in the FCM token registration API. The error was primarily caused by the logic falling through to a create() call even when a token record already existed for the current user.

🛠️ Changes
**Logic Fix:** Added an explicit early return for "Scenario 2.b" (Token exists but belongs to the current user). Previously, this scenario would continue execution and attempt to create a duplicate record. (which caused slack alerts)
**Race Condition Protection:** Switched the final create() call to an upsert(). This ensures that if two identical registration requests arrive simultaneously, the second one will gracefully update the record rather than crashing the API.