### PR TITLE
feat/url-redirect

### DIFF
--- a/src/pages/category/[slug].page.tsx
+++ b/src/pages/category/[slug].page.tsx
@@ -22,7 +22,7 @@ import {
   getCanonicalUrl,
 } from '@/pages/lib/seo';
 import { ExtendedCategory, ResponseApi } from '@/pages/lib/types';
-import { parseName } from '@/pages/lib/utils';
+import { isUUID, parseName } from '@/pages/lib/utils';
 import { homePageClasses } from '@/styles/classMaps';
 import { categoryIdClasses } from '@/styles/classMaps/category/id';
 import { appbarClasses } from '@/styles/classMaps/components/appbar';
@@ -89,6 +89,25 @@ export const getStaticProps: GetStaticProps = async ({
   const categorySlug = params?.slug as string;
 
   try {
+    // If the slug is actually a legacy fixed UUID, redirect to the friendly slug
+    if (isUUID(categorySlug)) {
+      const {
+        success: idSuccess,
+        data: categoryById,
+      }: ResponseApi<ExtendedCategory> = await (
+        await fetch(`${BASE_URL}/api/category?categoryId=${categorySlug}`)
+      ).json();
+
+      if (idSuccess && categoryById && categoryById.slug) {
+        return {
+          redirect: {
+            destination: `/${locale}/category/${categoryById.slug}`,
+            permanent: true,
+          },
+        };
+      }
+    }
+
     // Fetch the specific category
     const { success, data: categoryData }: ResponseApi<ExtendedCategory> =
       await (

--- a/src/pages/category/[slug].page.tsx
+++ b/src/pages/category/[slug].page.tsx
@@ -185,6 +185,7 @@ export const getStaticProps: GetStaticProps = async ({
         ogDescription: description,
         ogImage,
         breadcrumbJsonLd,
+        noIndex: true,
       };
     }
 

--- a/src/pages/category/index.page.tsx
+++ b/src/pages/category/index.page.tsx
@@ -29,6 +29,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     ogDescription: description,
     ogLocale: locale,
     ogType: 'website',
+    noIndex: true,
   };
 
   return {

--- a/src/pages/lib/utils.ts
+++ b/src/pages/lib/utils.ts
@@ -386,6 +386,12 @@ export function isNumeric(value: string): boolean {
   return !Number.isNaN(+value);
 }
 
+export function isUUID(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+    value,
+  );
+}
+
 export const getCookie = (name: string): string | undefined => {
   if (typeof window === 'undefined' || typeof document === 'undefined') {
     return undefined;

--- a/src/pages/product/[slug].page.tsx
+++ b/src/pages/product/[slug].page.tsx
@@ -35,7 +35,7 @@ import {
   SnackbarProps,
 } from '@/pages/lib/types';
 import { useUserContext } from '@/pages/lib/UserContext';
-import { parseName } from '@/pages/lib/utils';
+import { isUUID, parseName } from '@/pages/lib/utils';
 import { computeProductPriceTags } from '@/pages/product/utils';
 import { appbarClasses } from '@/styles/classMaps/components/appbar';
 import { productIndexPageClasses } from '@/styles/classMaps/product';
@@ -99,6 +99,22 @@ export const getStaticProps: GetStaticProps = async ({
   const productSlug = params?.slug as string;
 
   try {
+    // If the slug is actually a legacy fixed UUID, redirect to the friendly slug
+    if (isUUID(productSlug)) {
+      const productsById = await fetchProducts({ productId: productSlug });
+      const productById =
+        productsById && productsById.length > 0 ? productsById[0] : null;
+
+      if (productById && productById.slug) {
+        return {
+          redirect: {
+            destination: `/${locale}/product/${productById.slug}`,
+            permanent: true,
+          },
+        };
+      }
+    }
+
     // Fetch the specific product at build time
     const products = await fetchProducts({ productSlug });
     const product = products && products.length > 0 ? products[0] : null;

--- a/src/pages/product/index.page.tsx
+++ b/src/pages/product/index.page.tsx
@@ -1,3 +1,6 @@
+import { isUUID } from '@/pages/lib/utils';
+import { ExtendedCategory, PageSeoData, ResponseApi } from '@/pages/lib/types';
+import BASE_URL from '@/lib/ApiEndpoints';
 import ProductGridContent from '@/pages/components/ProductGridContent';
 import { BUSINESS_NAME, LOCALE_TO_OG_LOCALE } from '@/pages/lib/constants';
 import {
@@ -5,13 +8,37 @@ import {
   generateSearchTitle,
   getCanonicalUrl,
 } from '@/pages/lib/seo';
-import { PageSeoData } from '@/pages/lib/types';
 import { GetServerSideProps } from 'next';
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { searchKeyword } = context.query;
-
+  const { searchKeyword, categoryId } = context.query;
   const locale = context.locale || 'ru';
+
+  // If we have a legacy categoryId UUID, redirect to the new product-category/[slug]
+  if (categoryId && typeof categoryId === 'string' && isUUID(categoryId)) {
+    try {
+      const { success, data: category }: ResponseApi<ExtendedCategory> = await (
+        await fetch(`${BASE_URL}/api/category?categoryId=${categoryId}`)
+      ).json();
+
+      if (success && category && category.slug) {
+        // Build the new URL, preserving any other query params except categoryId
+        const query = { ...context.query };
+        delete query.categoryId;
+        const queryString = new URLSearchParams(query as any).toString();
+        const destination = `/${locale}/product-category/${category.slug}${queryString ? `?${queryString}` : ''}`;
+
+        return {
+          redirect: {
+            destination,
+            permanent: true,
+          },
+        };
+      }
+    } catch (error) {
+      console.error('Error during categoryId redirect lookup:', error);
+    }
+  }
 
   const messages = (await import(`../../i18n/${locale}.json`)).default;
 

--- a/src/pages/product/index.page.tsx
+++ b/src/pages/product/index.page.tsx
@@ -1,6 +1,4 @@
-import { isUUID } from '@/pages/lib/utils';
-import { ExtendedCategory, PageSeoData, ResponseApi } from '@/pages/lib/types';
-import BASE_URL from '@/lib/ApiEndpoints';
+import { PageSeoData } from '@/pages/lib/types';
 import ProductGridContent from '@/pages/components/ProductGridContent';
 import { BUSINESS_NAME, LOCALE_TO_OG_LOCALE } from '@/pages/lib/constants';
 import {
@@ -11,34 +9,8 @@ import {
 import { GetServerSideProps } from 'next';
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { searchKeyword, categoryId } = context.query;
+  const { searchKeyword } = context.query;
   const locale = context.locale || 'ru';
-
-  // If we have a legacy categoryId UUID, redirect to the new product-category/[slug]
-  if (categoryId && typeof categoryId === 'string' && isUUID(categoryId)) {
-    try {
-      const { success, data: category }: ResponseApi<ExtendedCategory> = await (
-        await fetch(`${BASE_URL}/api/category?categoryId=${categoryId}`)
-      ).json();
-
-      if (success && category && category.slug) {
-        // Build the new URL, preserving any other query params except categoryId
-        const query = { ...context.query };
-        delete query.categoryId;
-        const queryString = new URLSearchParams(query as any).toString();
-        const destination = `/${locale}/product-category/${category.slug}${queryString ? `?${queryString}` : ''}`;
-
-        return {
-          redirect: {
-            destination,
-            permanent: true,
-          },
-        };
-      }
-    } catch (error) {
-      console.error('Error during categoryId redirect lookup:', error);
-    }
-  }
 
   const messages = (await import(`../../i18n/${locale}.json`)).default;
 

--- a/src/pages/sitemap.xml.page.ts
+++ b/src/pages/sitemap.xml.page.ts
@@ -18,31 +18,11 @@ function generateSiteMap(
        <changefreq>daily</changefreq>
        <priority>1.0</priority>
      </url>
-     <url>
-       <loc>${BASE_URL}/${locale}/category</loc>
-       <changefreq>daily</changefreq>
-       <priority>0.8</priority>
-     </url>`;
+`;
        })
        .join('')}
 
-     <!-- Categories -->
-     ${categories
-       .filter(({ slug }) => slug != null)
-       .map(({ slug, updatedAt }) => {
-         return localeOptions
-           .map((locale) => {
-             return `
-        <url>
-            <loc>${BASE_URL}/${locale}/category/${slug}</loc>
-            <lastmod>${updatedAt.toISOString()}</lastmod>
-            <changefreq>weekly</changefreq>
-            <priority>0.7</priority>
-        </url>`;
-           })
-           .join('');
-       })
-       .join('')}
+
 
      <!-- Category Product Landing Pages -->
      ${categories

--- a/tests/e2e/fixtures/catalog-slugs.ts
+++ b/tests/e2e/fixtures/catalog-slugs.ts
@@ -8,4 +8,7 @@ export const E2E_CATALOG = {
   rootSlug: 'e2e-root-catalog',
   subSlug: 'e2e-sub-catalog',
   productSlug: 'e2e-catalog-phone',
+  rootUuid: '11111111-e2e0-4111-b111-111111111111',
+  subUuid: '22222222-e2e0-4222-b222-222222222222',
+  productUuid: '33333333-e2e0-4333-b333-333333333333',
 } as const;

--- a/tests/e2e/seed-e2e-catalog.ts
+++ b/tests/e2e/seed-e2e-catalog.ts
@@ -17,6 +17,7 @@ const name = (label: string) =>
 export async function seedE2eCatalog(prisma: PrismaClient): Promise<void> {
   const root = await prisma.category.create({
     data: {
+      id: E2E_CATALOG.rootUuid,
       name: name(E2E_CATALOG.rootName),
       slug: E2E_CATALOG.rootSlug,
       sortOrder: 0,
@@ -26,6 +27,7 @@ export async function seedE2eCatalog(prisma: PrismaClient): Promise<void> {
 
   const sub = await prisma.category.create({
     data: {
+      id: E2E_CATALOG.subUuid,
       name: name(E2E_CATALOG.subName),
       slug: E2E_CATALOG.subSlug,
       predecessorId: root.id,
@@ -43,6 +45,7 @@ export async function seedE2eCatalog(prisma: PrismaClient): Promise<void> {
 
   await prisma.product.create({
     data: {
+      id: E2E_CATALOG.productUuid,
       slug: E2E_CATALOG.productSlug,
       name: name(E2E_CATALOG.productName),
       categoryId: sub.id,

--- a/tests/e2e/seo-redirects.spec.ts
+++ b/tests/e2e/seo-redirects.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+
+import { E2E_CATALOG } from './fixtures/catalog-slugs';
+
+test.describe('SEO Redirections (Legacy ID to Slug)', () => {
+  test('redirects from legacy category UUID to category slug', async ({
+    page,
+  }) => {
+    // E2E_CATALOG provides real seed data containing fixed UUIDs
+    await page.goto(`/category/${E2E_CATALOG.subUuid}`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // The Next.js server naturally issues a 308 permanent redirect pushing the browser.
+    await expect(page).toHaveURL(
+      new RegExp(`category\\/${E2E_CATALOG.subSlug}`),
+      { timeout: 60_000 },
+    );
+  });
+
+  test('redirects from legacy product UUID to product slug', async ({
+    page,
+  }) => {
+    await page.goto(`/product/${E2E_CATALOG.productUuid}`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    await expect(page).toHaveURL(
+      new RegExp(`product\\/${E2E_CATALOG.productSlug}`),
+      { timeout: 60_000 },
+    );
+  });
+
+  test('redirects from product list index query param to isolated slug route', async ({
+    page,
+  }) => {
+    // We pass the categoryId parameter mimicking search/filter bars
+    await page.goto(`/product?categoryId=${E2E_CATALOG.subUuid}`, {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // It should transparently drop the param and redirect completely to product-category route
+    await expect(page).toHaveURL(
+      new RegExp(`product-category\\/${E2E_CATALOG.subSlug}`),
+      { timeout: 60_000 },
+    );
+  });
+});

--- a/tests/e2e/seo-redirects.spec.ts
+++ b/tests/e2e/seo-redirects.spec.ts
@@ -30,19 +30,4 @@ test.describe('SEO Redirections (Legacy ID to Slug)', () => {
       { timeout: 60_000 },
     );
   });
-
-  test('redirects from product list index query param to isolated slug route', async ({
-    page,
-  }) => {
-    // We pass the categoryId parameter mimicking search/filter bars
-    await page.goto(`/product?categoryId=${E2E_CATALOG.subUuid}`, {
-      waitUntil: 'domcontentloaded',
-    });
-
-    // It should transparently drop the param and redirect completely to product-category route
-    await expect(page).toHaveURL(
-      new RegExp(`product-category\\/${E2E_CATALOG.subSlug}`),
-      { timeout: 60_000 },
-    );
-  });
 });

--- a/tests/unit/pages/lib/utils.isUUID.test.ts
+++ b/tests/unit/pages/lib/utils.isUUID.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { isUUID } from '@/pages/lib/utils';
+
+describe('isUUID', () => {
+  it('returns true for a valid lowercase UUID v4', () => {
+    expect(isUUID('cd256c66-4efe-487e-903e-fa73850f214a')).toBe(true);
+  });
+
+  it('returns true for a valid uppercase UUID', () => {
+    expect(isUUID('CD256C66-4EFE-487E-903E-FA73850F214A')).toBe(true);
+  });
+
+  it('returns false for an empty string', () => {
+    expect(isUUID('')).toBe(false);
+  });
+
+  it('returns false for generic string slugs', () => {
+    expect(isUUID('my-cool-product')).toBe(false);
+    expect(isUUID('phones')).toBe(false);
+    expect(isUUID('iphone-15-pro-max')).toBe(false);
+  });
+
+  it('returns false for an invalid format resembling a UUID', () => {
+    // Missing a character
+    expect(isUUID('cd256c6-4efe-487e-903e-fa73850f214a')).toBe(false);
+    // Invalid characters (g, h, z)
+    expect(isUUID('zz256c66-4efe-487e-903e-fa73850f214a')).toBe(false);
+  });
+});


### PR DESCRIPTION
This PR introduces legacy-URL redirect support by detecting UUID-based identifiers in product/category routes and redirecting to the newer slug-based URLs, while also adjusting SEO/sitemap behavior accordingly.

Closes #305 

**Changes:**
- Add `isUUID()` helper and unit tests for UUID detection.
- Add redirects from legacy UUID-based product/category URLs to slug-based URLs (`getStaticProps` / `getServerSideProps`).
- Update sitemap + category SEO metadata (**remove category URLs from sitemap** and add `noIndex` to category pages, since category pages are just hierarchical navigation).

E.g
- category/id -> category/slug
- product/id -> product/slug
### Reviewed changes

Copilot reviewed 10 out of 10 changed files in this pull request and generated 5 comments.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| tests/unit/pages/product/slug.page.test.ts | Adds unit tests for product UUID→slug redirect behavior. |
| tests/unit/pages/product/index.page.test.ts | Adds unit tests for categoryId UUID→slug redirect on product index SSR. |
| tests/unit/pages/lib/utils.isUUID.test.ts | Adds unit tests for the new `isUUID()` helper. |
| tests/unit/pages/category/slug.page.test.ts | Adds unit tests for category UUID→slug redirect behavior. |
| src/pages/sitemap.xml.page.ts | Removes category URLs from the sitemap output, leaving product-category + product URLs. |
| src/pages/product/[slug].page.tsx | Adds SSG redirect when `[slug]` is a UUID (legacy) to `/product/[slug]`. |
| src/pages/lib/utils.ts | Introduces `isUUID()` helper. |
| src/pages/category/index.page.tsx | Sets `noIndex: true` on the category index page SEO data. |
| src/pages/category/[slug].page.tsx | Adds UUID→slug redirect and sets `noIndex: true` on category pages’ SEO data. |
</details>


---

💡 <a href="/xmobile-atamyrat/xmobile-v1/new/main?filename=.github/instructions/*.instructions.md" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Add Copilot custom instructions</a> for smarter, more guided reviews. <a href="https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Learn how to get started</a>.