### PR TITLE
Remove /ch/ locale from SEO

### DIFF
--- a/docs/seo-knowledge.md
+++ b/docs/seo-knowledge.md
@@ -104,7 +104,6 @@ All SEO-related strings (titles, descriptions, templates) are stored in the tran
 *   **URLs**: All indexable URLs include the locale (e.g., `/ru/product/123`).
 *   **Canonical**: Points to the current locale version, except for the 'ch' (Charjew) locale which canonicalizes to the 'tk' (Turkmen) version to consolidate duplicate content.
 *   **x-default**: Points to the 'ru' version (at `/ru/...`) as the default fallback.
-*   **Locale Persistence**: The application automatically synchronizes the `NEXT_LOCALE` cookie with the URL path and redirects unprefixed routes to the cached locale.
 *   **Schema**: Currently uses main local names (Turkmen) for store addresses to keep schema simple and verifiable by Google Maps.
 
 ### Why Centralized in `seo.ts`?

--- a/docs/seo-knowledge.md
+++ b/docs/seo-knowledge.md
@@ -101,9 +101,10 @@ This array drives the `LocalBusiness` schema generation. To add a new store, sim
 
 ### Localization Strategy
 All SEO-related strings (titles, descriptions, templates) are stored in the translation files (`src/i18n/*.json`) to support multiple locales (en, ru, tk, ch, tr).
-*   **URLs**: All URLs include the locale (e.g., `/ru/product/123`).
-*   **Canonical**: Points to itself (the current locale version).
-*   **x-default**: Points to the 'ru' version as the default fallback.
+*   **URLs**: All indexable URLs include the locale (e.g., `/ru/product/123`).
+*   **Canonical**: Points to the current locale version, except for the 'ch' (Charjew) locale which canonicalizes to the 'tk' (Turkmen) version to consolidate duplicate content.
+*   **x-default**: Points to the 'ru' version (at `/ru/...`) as the default fallback.
+*   **Locale Persistence**: The application automatically synchronizes the `NEXT_LOCALE` cookie with the URL path and redirects unprefixed routes to the cached locale.
 *   **Schema**: Currently uses main local names (Turkmen) for store addresses to keep schema simple and verifiable by Google Maps.
 
 ### Why Centralized in `seo.ts`?

--- a/src/pages/lib/constants.ts
+++ b/src/pages/lib/constants.ts
@@ -16,6 +16,13 @@ export const mobileAppBarHeight = 56;
 
 export const localeOptions = ['en', 'tk', 'ru', 'ch', 'tr'];
 
+/**
+ * Locales that should be indexed by search engines.
+ * Charjew (ch) is excluded because its content overlaps with Turkmen (tk).
+ * Pages on /ch/ still work for users but point their canonical to /tk/.
+ */
+export const INDEXABLE_LOCALES = localeOptions.filter((l) => l !== 'ch');
+
 export const drawerPaddingTopOffset = 2;
 
 export const MAIN_BG_COLOR = '#FFF';

--- a/src/pages/lib/seo.ts
+++ b/src/pages/lib/seo.ts
@@ -376,12 +376,13 @@ export function generateBreadcrumbJsonLd(
   homeLabel: string,
 ): BreadcrumbListJsonLd {
   const items: BreadcrumbJsonLdItem[] = [];
+  const targetLocale = locale === 'ch' ? 'tk' : locale;
 
   items.push({
     '@type': 'ListItem',
     position: 1,
     name: homeLabel,
-    item: `${BASE_URL}/${locale}`,
+    item: getCanonicalUrl(targetLocale, ''),
   });
 
   categoryPath.forEach((category, index) => {
@@ -389,7 +390,7 @@ export function generateBreadcrumbJsonLd(
       '@type': 'ListItem',
       position: index + 2,
       name: parseName(category.name, locale),
-      item: `${BASE_URL}/${locale}/category/${category.slug}`,
+      item: getCanonicalUrl(targetLocale, `category/${category.slug}`),
     });
   });
 

--- a/src/pages/lib/seo.ts
+++ b/src/pages/lib/seo.ts
@@ -34,11 +34,11 @@ export function getCanonicalUrl(locale: string, path: string): string {
 }
 
 /**
- * Generate hreflang links for all supported locales.
+ * Generate hreflang links for indexable/canonical locales.
  *
  * @param path - Page path without locale, e.g., "product/123"
  * @param defaultLocale - Default locale for x-default fallback (usually 'ru')
- * @returns Array of hreflang link objects for all canonical locales + x-default
+ * @returns Array of hreflang link objects for canonical locales + x-default
  *
  * SEO notes:
  * - Only canonical URLs should be included in hreflang.

--- a/src/pages/lib/seo.ts
+++ b/src/pages/lib/seo.ts
@@ -1,7 +1,8 @@
 import BASE_URL from '@/lib/ApiEndpoints';
 import {
   BUSINESS_NAME,
-  localeOptions,
+  DEFAULT_LOCALE,
+  INDEXABLE_LOCALES,
   META_DESC_MAX_LENGTH,
   PAGE_TITLE_MAX_LENGTH,
 } from '@/pages/lib/constants';
@@ -24,10 +25,12 @@ import { parseName } from '@/pages/lib/utils';
  * @see {@link ../../../docs/seo-knowledge.md} for details on Canonical URLs.
  */
 export function getCanonicalUrl(locale: string, path: string): string {
-  // Remove leading slash if present
+  // Normalize path by removing leading slash
   const cleanPath = path.startsWith('/') ? path.slice(1) : path;
 
-  return `${BASE_URL}/${locale}/${cleanPath}`;
+  const targetLocale = locale === 'ch' ? 'tk' : locale;
+
+  return `${BASE_URL}/${targetLocale}/${cleanPath}`;
 }
 
 /**
@@ -35,26 +38,30 @@ export function getCanonicalUrl(locale: string, path: string): string {
  *
  * @param path - Page path without locale, e.g., "product/123"
  * @param defaultLocale - Default locale for x-default fallback (usually 'ru')
- * @returns Array of hreflang link objects for all locales + x-default
+ * @returns Array of hreflang link objects for all canonical locales + x-default
  *
+ * SEO notes:
+ * - Only canonical URLs should be included in hreflang.
+ * - The 'ch' locale is excluded because it is consolidated into 'tk'
+ *   and should not appear as a separate alternate.
+ * - Each hreflang entry must correspond to a self-canonical page.
+ * - x-default is used as a fallback for unspecified languages/regions.
  * @see {@link ../../../docs/seo-knowledge.md} for details on Hreflang tags.
  */
 export function generateHreflangLinks(
   path: string,
-  defaultLocale: string = 'ru',
+  defaultLocale: string = DEFAULT_LOCALE,
 ): HreflangLink[] {
   const links: HreflangLink[] = [];
 
-  // Generate link for each supported locale
-  localeOptions.forEach((locale) => {
+  INDEXABLE_LOCALES.forEach((locale) => {
     links.push({
       locale,
       url: getCanonicalUrl(locale, path),
     });
   });
 
-  // Add x-default (fallback for unknown locales/regions),
-  // shown when Google can't determine user's language preference
+  // Add x-default (fallback page)
   links.push({
     locale: 'x-default',
     url: getCanonicalUrl(defaultLocale, path),

--- a/src/pages/lib/seo.ts
+++ b/src/pages/lib/seo.ts
@@ -30,7 +30,9 @@ export function getCanonicalUrl(locale: string, path: string): string {
 
   const targetLocale = locale === 'ch' ? 'tk' : locale;
 
-  return `${BASE_URL}/${targetLocale}/${cleanPath}`;
+  const localePath = cleanPath ? `${targetLocale}/${cleanPath}` : targetLocale;
+
+  return `${BASE_URL}/${localePath}`;
 }
 
 /**

--- a/src/pages/sitemap.xml.page.ts
+++ b/src/pages/sitemap.xml.page.ts
@@ -1,7 +1,7 @@
-import BASE_URL from '@/lib/ApiEndpoints';
 import dbClient from '@/lib/dbClient';
 import { GetServerSideProps } from 'next';
-import { localeOptions } from '@/pages/lib/constants';
+import { INDEXABLE_LOCALES } from '@/pages/lib/constants';
+import { getCanonicalUrl } from '@/pages/lib/seo';
 
 function generateSiteMap(
   products: { id: string; slug: string | null; updatedAt: Date }[],
@@ -10,34 +10,28 @@ function generateSiteMap(
   return `<?xml version="1.0" encoding="UTF-8"?>
    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
      <!-- Static Pages -->
-     ${localeOptions
-       .map((locale) => {
-         return `
+     ${INDEXABLE_LOCALES.map((locale) => {
+       return `
      <url>
-       <loc>${BASE_URL}/${locale}</loc>
+       <loc>${getCanonicalUrl(locale, '')}</loc>
        <changefreq>daily</changefreq>
        <priority>1.0</priority>
      </url>
 `;
-       })
-       .join('')}
-
-
+     }).join('')}
 
      <!-- Category Product Landing Pages -->
      ${categories
        .map(({ slug, updatedAt }) => {
-         return localeOptions
-           .map((locale) => {
-             return `
+         return INDEXABLE_LOCALES.map((locale) => {
+           return `
        <url>
-           <loc>${BASE_URL}/${locale}/product-category/${slug}</loc>
+           <loc>${getCanonicalUrl(locale, `product-category/${slug}`)}</loc>
            <lastmod>${updatedAt.toISOString()}</lastmod>
            <changefreq>daily</changefreq>
            <priority>0.8</priority>
        </url>`;
-           })
-           .join('');
+         }).join('');
        })
        .join('')}
 
@@ -45,17 +39,15 @@ function generateSiteMap(
      ${products
        .filter(({ slug }) => slug != null)
        .map(({ slug, updatedAt }) => {
-         return localeOptions
-           .map((locale) => {
-             return `
+         return INDEXABLE_LOCALES.map((locale) => {
+           return `
         <url>
-            <loc>${BASE_URL}/${locale}/product/${slug}</loc>
+            <loc>${getCanonicalUrl(locale, `product/${slug}`)}</loc>
             <lastmod>${updatedAt.toISOString()}</lastmod>
             <changefreq>daily</changefreq>
             <priority>0.9</priority>
         </url>`;
-           })
-           .join('');
+         }).join('');
        })
        .join('')}
  

--- a/tests/unit/pages/lib/seo.test.ts
+++ b/tests/unit/pages/lib/seo.test.ts
@@ -76,4 +76,19 @@ describe('generateHreflangLinks', () => {
     const links = generateHreflangLinks('product/42', 'ru');
     expect(links.some((l) => l.locale === 'ch')).toBe(false);
   });
+
+  it('generates breadcrumbs for ch locale pointing to tk master URLs', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const { generateBreadcrumbJsonLd } = await import('@/pages/lib/seo');
+    const breadcrumbs = generateBreadcrumbJsonLd(
+      [],
+      undefined,
+      'ch',
+      'Bash sahypa',
+    );
+
+    expect(breadcrumbs.itemListElement[0].item).toBe(
+      'https://xmobile.com.tm/tk',
+    );
+  });
 });

--- a/tests/unit/pages/lib/seo.test.ts
+++ b/tests/unit/pages/lib/seo.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { localeOptions } from '@/pages/lib/constants';
+import { INDEXABLE_LOCALES } from '@/pages/lib/constants';
 
 describe('getCanonicalUrl', () => {
   afterEach(() => {
@@ -33,6 +33,20 @@ describe('getCanonicalUrl', () => {
       'http://127.0.0.1:3003/en/about',
     );
   });
+
+  it('canonicalizes ch locale to tk', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const { getCanonicalUrl } = await import('@/pages/lib/seo');
+    expect(getCanonicalUrl('ch', 'product/1')).toBe(
+      'https://xmobile.com.tm/tk/product/1',
+    );
+  });
+
+  it('generates root path without trailing slash', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const { getCanonicalUrl } = await import('@/pages/lib/seo');
+    expect(getCanonicalUrl('ru', '')).toBe('https://xmobile.com.tm/ru');
+  });
 });
 
 describe('generateHreflangLinks', () => {
@@ -46,7 +60,7 @@ describe('generateHreflangLinks', () => {
     const { generateHreflangLinks } = await import('@/pages/lib/seo');
     const links = generateHreflangLinks('product/42', 'ru');
 
-    expect(links).toHaveLength(localeOptions.length + 1);
+    expect(links).toHaveLength(INDEXABLE_LOCALES.length + 1);
     expect(links.some((l) => l.locale === 'x-default')).toBe(true);
     expect(links.find((l) => l.locale === 'ru')?.url).toBe(
       'https://xmobile.com.tm/ru/product/42',
@@ -54,5 +68,12 @@ describe('generateHreflangLinks', () => {
     expect(links.find((l) => l.locale === 'x-default')?.url).toBe(
       'https://xmobile.com.tm/ru/product/42',
     );
+  });
+
+  it('excludes ch from hreflang links', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const { generateHreflangLinks } = await import('@/pages/lib/seo');
+    const links = generateHreflangLinks('product/42', 'ru');
+    expect(links.some((l) => l.locale === 'ch')).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #327 

Updates SEO generation to treat `ch` as a duplicate of `tk` by excluding `ch` from indexable surfaces (sitemap + hreflang) and canonicalizing `ch` URLs to `tk`, aligning with issue #327.

**Changes:**
- Introduces `INDEXABLE_LOCALES` (excluding `ch`) and uses it in sitemap generation.
- Updates `getCanonicalUrl` to canonicalize `ch -> tk`.
- Updates `generateHreflangLinks` to emit alternates only for indexable/canonical locales (plus `x-default`).