### PR TITLE
Send push notifications to superusers/admins for new chat requests

### DIFF
--- a/src/pages/api/chat/session.page.ts
+++ b/src/pages/api/chat/session.page.ts
@@ -5,8 +5,13 @@ import withAuth, {
 import { NextApiResponse } from 'next';
 
 import dbClient from '@/lib/dbClient';
+import { sendFCMWithCallbackFallback } from '@/lib/fcm/fcmService';
 import { ResponseApi } from '@/pages/lib/types';
 import { ChatStatus } from '@prisma/client';
+import {
+  createNotificationsForSessionRequest,
+  sendNotificationToWebSocketServer,
+} from '@/ws-server/lib/utils';
 
 const filepath = 'src/pages/api/chat/session.page.ts';
 
@@ -117,6 +122,30 @@ async function handler(
             },
           },
         });
+
+        createNotificationsForSessionRequest(newSession.id)
+          .then((notifications) => {
+            notifications.forEach((notification) => {
+              sendFCMWithCallbackFallback(
+                notification.userId,
+                notification,
+                sendNotificationToWebSocketServer,
+              ).catch((error) => {
+                console.error(
+                  filepath,
+                  `Failed to send notification to user ${notification.userId}:`,
+                  error,
+                );
+              });
+            });
+          })
+          .catch((error) => {
+            console.error(
+              filepath,
+              'Failed to create/send notifications for session request:',
+              error,
+            );
+          });
 
         return res.status(201).json({ success: true, data: newSession });
       }

--- a/src/pages/api/chat/session.page.ts
+++ b/src/pages/api/chat/session.page.ts
@@ -123,29 +123,31 @@ async function handler(
           },
         });
 
-        createNotificationsForSessionRequest(newSession.id)
-          .then((notifications) => {
-            notifications.forEach((notification) => {
-              sendFCMWithCallbackFallback(
-                notification.userId,
-                notification,
-                sendNotificationToWebSocketServer,
-              ).catch((error) => {
-                console.error(
-                  filepath,
-                  `Failed to send notification to user ${notification.userId}:`,
-                  error,
-                );
-              });
-            });
-          })
-          .catch((error) => {
-            console.error(
-              filepath,
-              'Failed to create/send notifications for session request:',
-              error,
-            );
-          });
+        try {
+          const notifications = await createNotificationsForSessionRequest(
+            newSession.id,
+          );
+          const notificationPromises = notifications.map((notification) =>
+            sendFCMWithCallbackFallback(
+              notification.userId,
+              notification,
+              sendNotificationToWebSocketServer,
+            ).catch((error) => {
+              console.error(
+                filepath,
+                `Failed to send notification to user ${notification.userId}:`,
+                error,
+              );
+            }),
+          );
+          await Promise.allSettled(notificationPromises);
+        } catch (error) {
+          console.error(
+            filepath,
+            'Failed to create/send notifications for session request:',
+            error,
+          );
+        }
 
         return res.status(201).json({ success: true, data: newSession });
       }

--- a/src/pages/chat/index.page.tsx
+++ b/src/pages/chat/index.page.tsx
@@ -94,10 +94,13 @@ export default function ChatPage() {
           return;
         }
 
-        // If sessions haven't loaded yet, wait for them
+        // If sessions haven't loaded yet, trigger load and wait
         if (sessions.length === 0) {
-          // Sessions are still loading, keep initializing state
-          return;
+          await loadSessions();
+          if (sessions.length === 0) {
+            setIsInitializing(false);
+            return;
+          }
         }
 
         setIsInitializing(true);

--- a/src/pages/chat/index.page.tsx
+++ b/src/pages/chat/index.page.tsx
@@ -95,9 +95,10 @@ export default function ChatPage() {
         }
 
         // If sessions haven't loaded yet, trigger load and wait
-        if (sessions.length === 0) {
-          await loadSessions();
-          if (sessions.length === 0) {
+        let currentSessions = sessions;
+        if (currentSessions.length === 0) {
+          currentSessions = await loadSessions();
+          if (currentSessions.length === 0) {
             setIsInitializing(false);
             return;
           }
@@ -105,7 +106,7 @@ export default function ChatPage() {
 
         setIsInitializing(true);
         setSessionError(null);
-        const session = sessions.find((s) => s.id === sessionId);
+        const session = currentSessions.find((s) => s.id === sessionId);
         if (session) {
           // Only join if we're not already in this session
           if (currentSession?.id !== sessionId) {

--- a/src/pages/lib/ChatContext.tsx
+++ b/src/pages/lib/ChatContext.tsx
@@ -24,7 +24,7 @@ interface ChatContextProps {
   sendMessage: (content: string) => void;
   joinSession: (sessionId: string) => Promise<boolean>;
   loadMessages: (sessionId: string, cursorId?: string) => Promise<void>;
-  loadSessions: () => Promise<void>;
+  loadSessions: () => Promise<ChatSession[]>;
   createSession: () => Promise<ChatSession | null>;
   endSession: (sessionId: string) => Promise<void>;
   setSessions: React.Dispatch<React.SetStateAction<ChatSession[]>>;
@@ -43,7 +43,7 @@ const ChatContext = createContext<ChatContextProps>({
   sendMessage: () => {},
   joinSession: async () => false,
   loadMessages: async () => {},
-  loadSessions: async () => {},
+  loadSessions: async () => [],
   createSession: async () => null,
   endSession: async () => {},
   setSessions: () => {},
@@ -76,10 +76,12 @@ export const ChatContextProvider = ({ children }: { children: ReactNode }) => {
       const data = await res.json();
       if (data.success) {
         setSessions(data.data);
+        return data.data;
       }
     } catch (err) {
       console.error(err);
     }
+    return [];
   }, [accessToken]);
 
   const loadMessages = useCallback(

--- a/src/ws-server/lib/utils.ts
+++ b/src/ws-server/lib/utils.ts
@@ -363,6 +363,53 @@ export async function createNotificationsForAdmins(
 }
 
 /**
+ * Creates notifications for all superusers when a new chat session request is created
+ */
+export async function createNotificationsForSessionRequest(
+  sessionId: string,
+): Promise<InAppNotification[]> {
+  try {
+    const adminUserIds = await getAllAdminUsers();
+
+    if (adminUserIds.length === 0) {
+      return [];
+    }
+
+    const session = await dbClient.chatSession.findUnique({
+      where: { id: sessionId },
+      include: {
+        users: {
+          select: { name: true },
+        },
+      },
+    });
+
+    const userName = session?.users?.[0]?.name || 'User';
+
+    const createdNotifications = await dbClient.$transaction(async (tx) => {
+      const notificationPromises = adminUserIds.map((adminId) =>
+        tx.inAppNotification.create({
+          data: {
+            userId: adminId,
+            sessionId,
+            type: NotificationType.CHAT_MESSAGE,
+            title: 'New chat request',
+            content: `${userName} wants to start a chat`,
+            isRead: false,
+          },
+        }),
+      );
+      return Promise.all(notificationPromises);
+    });
+
+    return createdNotifications as InAppNotification[];
+  } catch (error) {
+    console.error('createNotificationsForSessionRequest error:', error);
+    return [];
+  }
+}
+
+/**
  * Sends notifications to WebSocket server via HTTP endpoint
  * This is used when calling from API routes (which run in a different process)
  */

--- a/tests/integration/chat.integration.test.ts
+++ b/tests/integration/chat.integration.test.ts
@@ -1,7 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { PrismaClient, UserRole } from '@prisma/client';
+import { NotificationType, PrismaClient, UserRole } from '@prisma/client';
 import { createMocks } from 'node-mocks-http';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 
 import { resetPrismaGlobalSingleton } from './helpers/reset-prisma-global';
 import { createStaffPrincipal } from './shared/staff-token';
@@ -10,6 +18,7 @@ import {
   prepareIntegrationWorker,
   teardownIntegrationWorker,
 } from './shared/worker-env';
+import { sendFCMWithCallbackFallback } from '@/lib/fcm/fcmService';
 
 describe('Chat API (integration)', () => {
   let prisma: PrismaClient;
@@ -26,6 +35,10 @@ describe('Chat API (integration)', () => {
     await prisma?.$disconnect();
     await resetPrismaGlobalSingleton();
     teardownIntegrationWorker();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
   it('FREE user lists empty sessions then creates one (201)', async () => {
@@ -88,6 +101,60 @@ describe('Chat API (integration)', () => {
     expect(second.res._getStatusCode()).toBe(409);
 
     await prisma.chatSession.delete({ where: { id: sessionId } });
+  });
+
+  it('FREE session creation creates staff notifications and triggers FCM callback', async () => {
+    const free = await signupTestUser('chat-notify');
+    const admin = await createStaffPrincipal(prisma, UserRole.ADMIN);
+    const superuser = await createStaffPrincipal(prisma, UserRole.SUPERUSER);
+    const handler = (await import('@/pages/api/chat/session.page')).default;
+
+    const post = createMocks({
+      method: 'POST',
+      url: '/api/chat/session',
+      headers: { authorization: `Bearer ${free.accessToken}` },
+    });
+    await handler(
+      post.req as unknown as NextApiRequest,
+      post.res as unknown as NextApiResponse,
+    );
+    expect(post.res._getStatusCode()).toBe(201);
+    const sessionId = JSON.parse(post.res._getData() as string).data.id;
+
+    const notifications = await prisma.inAppNotification.findMany({
+      where: { sessionId },
+      orderBy: { userId: 'asc' },
+    });
+    expect(notifications).toHaveLength(2);
+    expect(notifications.map((notification) => notification.userId)).toEqual(
+      [admin.userId, superuser.userId].sort(),
+    );
+    expect(
+      notifications.every(
+        (notification) =>
+          notification.type === NotificationType.CHAT_MESSAGE &&
+          notification.isRead === false,
+      ),
+    ).toBe(true);
+
+    const sendFCMMock = vi.mocked(sendFCMWithCallbackFallback);
+    expect(sendFCMMock).toHaveBeenCalledTimes(2);
+
+    const notifiedUserIds = new Set(
+      sendFCMMock.mock.calls.map(([userId]) => userId as string),
+    );
+    expect(notifiedUserIds).toEqual(new Set([admin.userId, superuser.userId]));
+
+    const notifiedIdsFromCalls = new Set(
+      sendFCMMock.mock.calls.map(([, notification]) => notification.id),
+    );
+    expect(notifiedIdsFromCalls).toEqual(
+      new Set(notifications.map((notification) => notification.id)),
+    );
+
+    await prisma.chatSession.delete({ where: { id: sessionId } });
+    await prisma.user.delete({ where: { id: admin.userId } });
+    await prisma.user.delete({ where: { id: superuser.userId } });
   });
 
   it('ADMIN joins PENDING session via sessionActions', async () => {

--- a/tests/integration/chat.integration.test.ts
+++ b/tests/integration/chat.integration.test.ts
@@ -125,20 +125,23 @@ describe('Chat API (integration)', () => {
       where: { sessionId },
       orderBy: { userId: 'asc' },
     });
-    expect(notifications).toHaveLength(2);
-    expect(notifications.map((notification) => notification.userId)).toEqual(
-      [admin.userId, superuser.userId].sort(),
+    expect(notifications.length).toBeGreaterThanOrEqual(2);
+    const notificationByUserId = new Map(
+      notifications.map((notification) => [notification.userId, notification]),
     );
-    expect(
-      notifications.every(
-        (notification) =>
-          notification.type === NotificationType.CHAT_MESSAGE &&
-          notification.isRead === false,
-      ),
-    ).toBe(true);
+    expect(notificationByUserId.has(admin.userId)).toBe(true);
+    expect(notificationByUserId.has(superuser.userId)).toBe(true);
+    expect(notificationByUserId.get(admin.userId)?.type).toBe(
+      NotificationType.CHAT_MESSAGE,
+    );
+    expect(notificationByUserId.get(superuser.userId)?.type).toBe(
+      NotificationType.CHAT_MESSAGE,
+    );
+    expect(notificationByUserId.get(admin.userId)?.isRead).toBe(false);
+    expect(notificationByUserId.get(superuser.userId)?.isRead).toBe(false);
 
     const sendFCMMock = vi.mocked(sendFCMWithCallbackFallback);
-    expect(sendFCMMock).toHaveBeenCalledTimes(2);
+    expect(sendFCMMock).toHaveBeenCalledTimes(notifications.length);
 
     const notifiedUserIds = new Set(
       sendFCMMock.mock.calls.map(([userId]) => userId as string),

--- a/tests/integration/chat.integration.test.ts
+++ b/tests/integration/chat.integration.test.ts
@@ -1,5 +1,5 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
 import { NotificationType, PrismaClient, UserRole } from '@prisma/client';
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { createMocks } from 'node-mocks-http';
 import {
   afterAll,
@@ -11,14 +11,14 @@ import {
   vi,
 } from 'vitest';
 
+import { sendFCMWithCallbackFallback } from '@/lib/fcm/fcmService';
 import { resetPrismaGlobalSingleton } from './helpers/reset-prisma-global';
-import { createStaffPrincipal } from './shared/staff-token';
 import { signupTestUser } from './shared/signup-test-user';
+import { createStaffPrincipal } from './shared/staff-token';
 import {
   prepareIntegrationWorker,
   teardownIntegrationWorker,
 } from './shared/worker-env';
-import { sendFCMWithCallbackFallback } from '@/lib/fcm/fcmService';
 
 describe('Chat API (integration)', () => {
   let prisma: PrismaClient;
@@ -146,7 +146,8 @@ describe('Chat API (integration)', () => {
     const notifiedUserIds = new Set(
       sendFCMMock.mock.calls.map(([userId]) => userId as string),
     );
-    expect(notifiedUserIds).toEqual(new Set([admin.userId, superuser.userId]));
+    expect(notifiedUserIds.has(admin.userId)).toBe(true);
+    expect(notifiedUserIds.has(superuser.userId)).toBe(true);
 
     const notifiedIdsFromCalls = new Set(
       sendFCMMock.mock.calls.map(([, notification]) => notification.id),


### PR DESCRIPTION
**Issues:**

1. When user creates a new _pending_ chat request, notification was not sent to admins/superusers, code used to return only **success**. 
2. When accessing via deeplink it tries to open the chat when the sessions array is empty

**Fixes:**

1. Send push notifications when new chat session is created
2. Load sessions before checking session existance on deep link