### PR TITLE
fix/block-product-image-crawling

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -14,4 +14,7 @@ Disallow: /procurement/
 Disallow: /*/procurement/
 Disallow: /server-logs/
 Disallow: /*/server-logs/
+Disallow: /media/product/
+Disallow: /media/category/
+Disallow: /api/localImage?imgUrl=
 Sitemap: https://xmobile.com.tm/sitemap.xml


### PR DESCRIPTION
- block image's served via nginx or api from being crawled

Closes #351 