### PR TITLE
feat/chat-session-date-indicator

### DIFF
--- a/src/pages/api/chat/session.page.ts
+++ b/src/pages/api/chat/session.page.ts
@@ -43,6 +43,8 @@ async function handler(
               select: {
                 senderId: true,
                 senderRole: true,
+                content: true,
+                createdAt: true,
               },
             },
           },

--- a/src/pages/components/chat/ChatBubble.tsx
+++ b/src/pages/components/chat/ChatBubble.tsx
@@ -48,7 +48,7 @@ const ChatBubble = ({ message, isMe, senderIndicator }: ChatBubbleProps) => {
       </Paper>
 
       {/* Timestamp & Status */}
-      <Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
         <Typography
           className={chatClasses.bubble.timestamp}
           sx={{ color: '#9E9E9E' }}

--- a/src/pages/components/chat/ChatBubble.tsx
+++ b/src/pages/components/chat/ChatBubble.tsx
@@ -48,23 +48,12 @@ const ChatBubble = ({ message, isMe, senderIndicator }: ChatBubbleProps) => {
       </Paper>
 
       {/* Timestamp & Status */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-        {senderIndicator && (
-          <Typography
-            sx={{
-              color: '#9E9E9E',
-              fontSize: '0.75rem',
-              mr: 0.5,
-              fontWeight: 500,
-            }}
-          >
-            {senderIndicator} •
-          </Typography>
-        )}
+      <Box>
         <Typography
           className={chatClasses.bubble.timestamp}
           sx={{ color: '#9E9E9E' }}
         >
+          {senderIndicator ? `${senderIndicator} • ` : ''}
           {new Date(
             message.timestamp ||
               message.date ||

--- a/src/pages/components/chat/ChatSessionList.tsx
+++ b/src/pages/components/chat/ChatSessionList.tsx
@@ -1,6 +1,7 @@
 import { useChatContext } from '@/pages/lib/ChatContext';
 import { usePlatform } from '@/pages/lib/PlatformContext';
 import { useUserContext } from '@/pages/lib/UserContext';
+import { TK_MONTHS_SHORT } from '@/pages/lib/constants';
 import { ChatSession } from '@/pages/lib/types';
 import { chatClasses } from '@/styles/classMaps/components/chat';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
@@ -28,7 +29,7 @@ const formatLastActiveDate = (dateString: string, locale: string = 'en') => {
   const date = new Date(dateString);
   const now = new Date();
 
-  // Map 'ch' locale to 'tk' (Turkmen)
+  // map 'ch' locale to 'tk' (Turkmen)
   const activeLocale = locale === 'ch' ? 'tk' : locale;
 
   const isToday =
@@ -43,14 +44,24 @@ const formatLastActiveDate = (dateString: string, locale: string = 'en') => {
     });
   }
   if (date.getFullYear() === now.getFullYear()) {
-    // Show [Month] [dd] for the current year
+    if (activeLocale === 'tk') {
+      // for Turkmen, use custom short month names
+      const month = TK_MONTHS_SHORT[date.getMonth()];
+      const day = date.getDate();
+      return `${month} ${day}`;
+    }
+
     return date.toLocaleDateString(activeLocale, {
       month: 'short',
       day: 'numeric',
     });
   }
-  // Show dd.mm.yy for previous years
-  return `${String(date.getDate()).padStart(2, '0')}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getFullYear()).slice(-2)}`;
+  // show dd.mm.yy for previous years
+  return date.toLocaleDateString(activeLocale, {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
 };
 
 const ChatSessionList = ({ onSelectSession }: ChatSessionListProps) => {

--- a/src/pages/components/chat/ChatSessionList.tsx
+++ b/src/pages/components/chat/ChatSessionList.tsx
@@ -23,6 +23,24 @@ interface ChatSessionListProps {
   onSelectSession: (session: ChatSession) => void;
 }
 
+const formatLastActiveDate = (dateString: string) => {
+  const date = new Date(dateString);
+  const now = new Date();
+
+  const isToday =
+    date.getDate() === now.getDate() &&
+    date.getMonth() === now.getMonth() &&
+    date.getFullYear() === now.getFullYear();
+
+  if (isToday) {
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  }
+  if (date.getFullYear() === now.getFullYear()) {
+    return `${String(date.getDate()).padStart(2, '0')}.${String(date.getMonth() + 1).padStart(2, '0')}`;
+  }
+  return `${String(date.getDate()).padStart(2, '0')}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getFullYear()).slice(-2)}`;
+};
+
 const ChatSessionList = ({ onSelectSession }: ChatSessionListProps) => {
   const { user } = useUserContext();
   const { sessions, loadSessions } = useChatContext();
@@ -115,7 +133,7 @@ const ChatSessionList = ({ onSelectSession }: ChatSessionListProps) => {
                   <Box sx={{ position: 'relative', flex: 1 }}>
                     <ListItemText
                       primary={userInfo}
-                      secondary={`${t('chatLastActive')}: ${new Date(session.updatedAt).toLocaleTimeString()}`}
+                      secondary={`${t('chatLastActive')}: ${formatLastActiveDate(session.updatedAt as string)}`}
                       primaryTypographyProps={{
                         fontSize: '14px',
                         fontWeight: 500,
@@ -184,7 +202,7 @@ const ChatSessionList = ({ onSelectSession }: ChatSessionListProps) => {
                     <Box sx={{ position: 'relative', flex: 1 }}>
                       <ListItemText
                         primary={userInfo}
-                        secondary={`${t('chatLastActive')}: ${new Date(session.updatedAt).toLocaleTimeString()}`}
+                        secondary={`${t('chatLastActive')}: ${formatLastActiveDate(session.updatedAt as string)}`}
                         primaryTypographyProps={{
                           fontSize: '14px',
                           fontWeight: 500,

--- a/src/pages/components/chat/ChatSessionList.tsx
+++ b/src/pages/components/chat/ChatSessionList.tsx
@@ -56,7 +56,8 @@ const formatLastActiveDate = (dateString: string, locale: string = 'en') => {
       day: 'numeric',
     });
   }
-  // show dd.mm.yy for previous years
+
+  // show full date for previous years
   return date.toLocaleDateString(activeLocale, {
     day: '2-digit',
     month: '2-digit',

--- a/src/pages/components/chat/ChatSessionList.tsx
+++ b/src/pages/components/chat/ChatSessionList.tsx
@@ -17,15 +17,19 @@ import {
   Typography,
 } from '@mui/material';
 import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
 interface ChatSessionListProps {
   onSelectSession: (session: ChatSession) => void;
 }
 
-const formatLastActiveDate = (dateString: string) => {
+const formatLastActiveDate = (dateString: string, locale: string = 'en') => {
   const date = new Date(dateString);
   const now = new Date();
+
+  // Map 'ch' locale to 'tk' (Turkmen)
+  const activeLocale = locale === 'ch' ? 'tk' : locale;
 
   const isToday =
     date.getDate() === now.getDate() &&
@@ -33,11 +37,19 @@ const formatLastActiveDate = (dateString: string) => {
     date.getFullYear() === now.getFullYear();
 
   if (isToday) {
-    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    return date.toLocaleTimeString(activeLocale, {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
   }
   if (date.getFullYear() === now.getFullYear()) {
-    return `${String(date.getDate()).padStart(2, '0')}.${String(date.getMonth() + 1).padStart(2, '0')}`;
+    // Show [Month] [dd] for the current year
+    return date.toLocaleDateString(activeLocale, {
+      month: 'short',
+      day: 'numeric',
+    });
   }
+  // Show dd.mm.yy for previous years
   return `${String(date.getDate()).padStart(2, '0')}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getFullYear()).slice(-2)}`;
 };
 
@@ -46,6 +58,8 @@ const ChatSessionList = ({ onSelectSession }: ChatSessionListProps) => {
   const { sessions, loadSessions } = useChatContext();
   const platform = usePlatform();
   const t = useTranslations();
+  const router = useRouter();
+  const locale = router.locale || 'en';
 
   useEffect(() => {
     loadSessions();
@@ -133,7 +147,7 @@ const ChatSessionList = ({ onSelectSession }: ChatSessionListProps) => {
                   <Box sx={{ position: 'relative', flex: 1 }}>
                     <ListItemText
                       primary={userInfo}
-                      secondary={`${t('chatLastActive')}: ${formatLastActiveDate(session.updatedAt as string)}`}
+                      secondary={`${t('chatLastActive')}: ${formatLastActiveDate(session.updatedAt as string, locale)}`}
                       primaryTypographyProps={{
                         fontSize: '14px',
                         fontWeight: 500,
@@ -202,7 +216,7 @@ const ChatSessionList = ({ onSelectSession }: ChatSessionListProps) => {
                     <Box sx={{ position: 'relative', flex: 1 }}>
                       <ListItemText
                         primary={userInfo}
-                        secondary={`${t('chatLastActive')}: ${formatLastActiveDate(session.updatedAt as string)}`}
+                        secondary={`${t('chatLastActive')}: ${formatLastActiveDate(session.updatedAt as string, locale)}`}
                         primaryTypographyProps={{
                           fontSize: '14px',
                           fontWeight: 500,

--- a/src/pages/components/chat/ChatSessionList.tsx
+++ b/src/pages/components/chat/ChatSessionList.tsx
@@ -1,8 +1,8 @@
 import { useChatContext } from '@/pages/lib/ChatContext';
-import { usePlatform } from '@/pages/lib/PlatformContext';
+import { Platform, usePlatform } from '@/pages/lib/PlatformContext';
 import { useUserContext } from '@/pages/lib/UserContext';
 import { TK_MONTHS_SHORT } from '@/pages/lib/constants';
-import { ChatSession } from '@/pages/lib/types';
+import { ChatSession, ProtectedUser } from '@/pages/lib/types';
 import { chatClasses } from '@/styles/classMaps/components/chat';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {
@@ -62,6 +62,117 @@ const formatLastActiveDate = (dateString: string, locale: string = 'en') => {
     month: '2-digit',
     year: 'numeric',
   });
+};
+
+const SessionListItem = ({
+  session: chatSession,
+  user,
+  locale,
+  platform,
+  onClick,
+}: {
+  session: ChatSession;
+  user: ProtectedUser | null;
+  locale: string;
+  platform: Platform;
+  onClick: (session: ChatSession) => void;
+}) => {
+  const t = useTranslations();
+  const sessionUser =
+    chatSession.users?.find((u) => u.grade === 'FREE') ||
+    chatSession.users?.[0];
+  const userInfo = sessionUser
+    ? `${sessionUser.name} (${sessionUser.email}${sessionUser.phoneNumber ? `, ${sessionUser.phoneNumber}` : ''})`
+    : 'User';
+
+  const lastMessage = chatSession.messages?.[0];
+  const awaitingAdminReply = lastMessage?.senderRole === 'FREE';
+
+  let senderName = '';
+  if (lastMessage) {
+    if (lastMessage.senderRole === 'FREE') {
+      senderName = sessionUser ? sessionUser.name : t('chatGuest');
+    } else if (lastMessage.senderId === user?.id) {
+      senderName = t('chatYou');
+    } else {
+      senderName = t('chatCustomerSupport');
+    }
+  }
+
+  const messageSnippet = lastMessage
+    ? `${senderName}: ${lastMessage.content}`
+    : '';
+
+  const messageDate = lastMessage
+    ? formatLastActiveDate(lastMessage.createdAt as string, locale)
+    : formatLastActiveDate(chatSession.updatedAt as string, locale);
+
+  return (
+    <ListItemButton
+      className={chatClasses.sessionList.listItem[platform]}
+      onClick={() => onClick(chatSession)}
+      sx={{
+        '&:hover': { backgroundColor: '#F6F6F6' },
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: 1,
+      }}
+    >
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography
+          sx={{
+            fontSize: '14px',
+            fontWeight: 500,
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {userInfo}
+        </Typography>
+        <Typography
+          sx={{
+            fontSize: '12px',
+            color: '#838383',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {messageSnippet}
+        </Typography>
+      </Box>
+
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-end',
+          gap: 0.5,
+          flexShrink: 0,
+        }}
+      >
+        <Typography
+          sx={{
+            fontSize: '11px',
+            color: '#838383',
+          }}
+        >
+          {messageDate}
+        </Typography>
+        {awaitingAdminReply && (
+          <Box
+            sx={{
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              backgroundColor: '#ff624c',
+            }}
+          />
+        )}
+      </Box>
+    </ListItemButton>
+  );
 };
 
 const ChatSessionList = ({ onSelectSession }: ChatSessionListProps) => {
@@ -137,52 +248,16 @@ const ChatSessionList = ({ onSelectSession }: ChatSessionListProps) => {
                 />
               </ListItem>
             )}
-            {openSessions.map((session) => {
-              const sessionUser =
-                session.users?.find((u) => u.grade === 'FREE') ||
-                session.users?.[0]; // Fallback to first user if FREE user not explicitly found
-              const userInfo = sessionUser
-                ? `${sessionUser.name} (${sessionUser.email}${sessionUser.phoneNumber ? `, ${sessionUser.phoneNumber}` : ''})`
-                : 'User';
-              const lastMessage = (session as any).messages?.[0];
-              const hasUnread = lastMessage?.senderRole === 'FREE';
-              return (
-                <ListItemButton
-                  key={session.id}
-                  className={chatClasses.sessionList.listItem[platform]}
-                  onClick={() => handleSessionClick(session)}
-                  sx={{
-                    '&:hover': { backgroundColor: '#F6F6F6' },
-                  }}
-                >
-                  <Box sx={{ position: 'relative', flex: 1 }}>
-                    <ListItemText
-                      primary={userInfo}
-                      secondary={`${t('chatLastActive')}: ${formatLastActiveDate(session.updatedAt as string, locale)}`}
-                      primaryTypographyProps={{
-                        fontSize: '14px',
-                        fontWeight: 500,
-                      }}
-                      secondaryTypographyProps={{
-                        fontSize: '12px',
-                        color: '#838383',
-                      }}
-                    />
-                  </Box>
-                  {hasUnread && (
-                    <Box
-                      sx={{
-                        width: 8,
-                        height: 8,
-                        borderRadius: '50%',
-                        backgroundColor: '#ff624c',
-                        flexShrink: 0,
-                      }}
-                    />
-                  )}
-                </ListItemButton>
-              );
-            })}
+            {openSessions.map((session) => (
+              <SessionListItem
+                key={session.id}
+                session={session}
+                user={user}
+                locale={locale}
+                platform={platform}
+                onClick={handleSessionClick}
+              />
+            ))}
           </List>
         </AccordionDetails>
       </Accordion>
@@ -208,39 +283,16 @@ const ChatSessionList = ({ onSelectSession }: ChatSessionListProps) => {
                   />
                 </ListItem>
               )}
-              {closedSessions.map((session) => {
-                const sessionUser = session.users?.find(
-                  (u) => u.grade === 'FREE',
-                );
-                const userInfo = sessionUser
-                  ? `${sessionUser.name} (${sessionUser.email}${sessionUser.phoneNumber ? `, ${sessionUser.phoneNumber}` : ''})`
-                  : 'User';
-                return (
-                  <ListItemButton
-                    key={session.id}
-                    className={chatClasses.sessionList.listItem[platform]}
-                    onClick={() => handleSessionClick(session)}
-                    sx={{
-                      '&:hover': { backgroundColor: '#F6F6F6' },
-                    }}
-                  >
-                    <Box sx={{ position: 'relative', flex: 1 }}>
-                      <ListItemText
-                        primary={userInfo}
-                        secondary={`${t('chatLastActive')}: ${formatLastActiveDate(session.updatedAt as string, locale)}`}
-                        primaryTypographyProps={{
-                          fontSize: '14px',
-                          fontWeight: 500,
-                        }}
-                        secondaryTypographyProps={{
-                          fontSize: '12px',
-                          color: '#838383',
-                        }}
-                      />
-                    </Box>
-                  </ListItemButton>
-                );
-              })}
+              {closedSessions.map((session) => (
+                <SessionListItem
+                  key={session.id}
+                  session={session}
+                  user={user}
+                  locale={locale}
+                  platform={platform}
+                  onClick={handleSessionClick}
+                />
+              ))}
             </List>
           </AccordionDetails>
         </Accordion>

--- a/src/pages/components/chat/ChatWindow.tsx
+++ b/src/pages/components/chat/ChatWindow.tsx
@@ -104,31 +104,68 @@ const ChatWindow = () => {
             {t('chatStartConversation')}
           </Typography>
         ) : (
-          messages.map((msg) => {
-            const isAdminMessage =
-              msg.senderRole === 'ADMIN' || msg.senderRole === 'SUPERUSER';
-            const isMe = msg.senderId === user?.id;
+          (() => {
+            const elements: JSX.Element[] = [];
+            let lastDateKey: string | null = null;
 
-            let senderIndicator;
-            if (isMe) {
-              senderIndicator = t('chatYou') || 'You';
-            } else if (isAdminMessage) {
-              senderIndicator =
-                msg.senderName || `Admin (${msg.senderId.slice(-4)})`;
-            }
+            messages.forEach((msg) => {
+              const date = new Date(
+                msg.date || msg.createdAt || msg.timestamp || Date.now(),
+              );
+              const dateKey = date.toDateString();
 
-            const key =
-              msg.messageId || msg.tempId || `msg-${msg.senderId}-${msg.date}`;
+              if (dateKey !== lastDateKey) {
+                elements.push(
+                  <Box
+                    key={`d-${dateKey}`}
+                    sx={{ display: 'flex', justifyContent: 'center', my: 1 }}
+                  >
+                    <Typography
+                      sx={{
+                        px: 2,
+                        py: 0.4,
+                        bgcolor: 'grey.300',
+                        color: 'text.secondary',
+                        borderRadius: '999px',
+                        fontSize: '12px',
+                      }}
+                    >
+                      {date.toLocaleDateString()}
+                    </Typography>
+                  </Box>,
+                );
+                lastDateKey = dateKey;
+              }
 
-            return (
-              <ChatBubble
-                key={key}
-                message={msg}
-                isMe={isMe}
-                senderIndicator={senderIndicator}
-              />
-            );
-          })
+              const isAdminMessage =
+                msg.senderRole === 'ADMIN' || msg.senderRole === 'SUPERUSER';
+              const isMe = msg.senderId === user?.id;
+
+              let senderIndicator;
+              if (isMe) {
+                senderIndicator = t('chatYou') || 'You';
+              } else if (isAdminMessage) {
+                senderIndicator =
+                  msg.senderName || `Admin (${msg.senderId.slice(-4)})`;
+              }
+
+              const key =
+                msg.messageId ||
+                msg.tempId ||
+                `msg-${msg.senderId}-${msg.date}`;
+
+              elements.push(
+                <ChatBubble
+                  key={key}
+                  message={msg}
+                  isMe={isMe}
+                  senderIndicator={senderIndicator}
+                />,
+              );
+            });
+
+            return elements;
+          })()
         )}
       </Box>
 

--- a/src/pages/lib/constants.ts
+++ b/src/pages/lib/constants.ts
@@ -138,3 +138,18 @@ export const LOCALE_TO_OG_LOCALE = {
   ch: 'tk_TM',
   tr: 'tr_TR',
 } as const;
+
+export const TK_MONTHS_SHORT = [
+  'Ýan',
+  'Few',
+  'Mar',
+  'Apr',
+  'Maý',
+  'Iýn',
+  'Iýl',
+  'Awg',
+  'Sen',
+  'Okt',
+  'Noý',
+  'Dek',
+];

--- a/src/pages/lib/types.ts
+++ b/src/pages/lib/types.ts
@@ -37,20 +37,6 @@ export interface ExtendedProduct extends Product {
 
 export interface ProtectedUser extends Omit<User, 'password'> {}
 
-export interface ChatSession {
-  id: string;
-  status: 'PENDING' | 'ACTIVE' | 'CLOSED';
-  createdAt: string | Date;
-  updatedAt: string | Date;
-  users?: ProtectedUser[];
-}
-
-export interface GetMessagesRequest {
-  type: 'get_messages';
-  sessionId: string;
-  cursorId?: string;
-}
-
 export interface ChatMessage {
   type: 'message';
   sessionId: string;
@@ -65,7 +51,17 @@ export interface ChatMessage {
   date?: Date | string;
   timestamp?: string;
   updatedAt?: Date | string;
+  createdAt?: Date | string;
   status?: 'sending' | 'sent' | 'error';
+}
+
+export interface ChatSession {
+  id: string;
+  status: 'PENDING' | 'ACTIVE' | 'CLOSED';
+  createdAt: string | Date;
+  updatedAt: string | Date;
+  users?: ProtectedUser[];
+  messages?: Partial<ChatMessage>[];
 }
 
 export interface HistoryResponseMessage {


### PR DESCRIPTION
Closes #353 

Adds date-awareness to the chat UI by introducing per-day separators in the message stream and showing a “last active” date/time indicator in the admin chat session list, supported by additional message fields coming from the sessions API.

**Changes:**
- Add day-separator rendering in `ChatWindow` and adjust `ChatBubble` timestamp rendering layout.
- Enhance admin session list items with last-message snippet + localized “last active” formatting (including custom Turkmen month abbreviations).
- Extend types and sessions API to include last-message `content` and `createdAt` for admin session listing.