### PR TITLE
fix: coerce quantity to number in cart schemas

### DIFF
--- a/src/pages/api/guest/cart.page.ts
+++ b/src/pages/api/guest/cart.page.ts
@@ -10,12 +10,12 @@ const filepath = 'src/pages/api/guest/cart.page.ts';
 
 const createSchema = z.object({
   productId: z.string(),
-  quantity: z.number().int().min(1),
+  quantity: z.coerce.number().int().min(1),
 });
 
 const updateSchema = z.object({
   id: z.string(),
-  quantity: z.number().int().min(1),
+  quantity: z.coerce.number().int().min(1),
 });
 
 const deleteSchema = z.object({


### PR DESCRIPTION
The issue is that quantity is being sent as a string in the request body (e.g., from a form or JSON where it's "1" instead of 1), but z.number() requires a number type, it doesn't coerce strings, so we recieved these error messages:

[ERROR] src/pages/api/guest/cart.page.ts [
  {
    "code": "too_small",
    "minimum": 1,
    "type": "number",
    "inclusive": true,
    "exact": false,
    "message": "Number must be greater than or equal to 1",
    "path": [
      "quantity"
    ]
  }
]
ZodError: [
  {
    "code": "too_small",
    "minimum": 1,
    "type": "number",
    "inclusive": true,
    "exact": false,
    "message": "Number must be greater than or equal to 1",
    "path": [
      "quantity"
    ]
  }
]
    at get error [as error] (file:///home/ubuntu/xmobile-v1/node_modules/zod/lib/index.mjs:587:31)
    at ZodObject.parse (file:///home/ubuntu/xmobile-v1/node_modules/zod/lib/index.mjs:663:22)
    at d (/home/ubuntu/xmobile-v1/.next/server/pages/api/guest/cart.js:1:2352)
    at K (/home/ubuntu/xmobile-v1/node_modules/next/dist/compiled/next-server/pages-api.runtime.prod.js:20:16887)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async U.render (/home/ubuntu/xmobile-v1/node_modules/next/dist/compiled/next-server/pages-api.runtime.prod.js:20:17520)
    at async NextNodeServer.runApi (/home/ubuntu/xmobile-v1/node_modules/next/dist/server/next-server.js:603:9)
    at async NextNodeServer.handleCatchallRenderRequest (/home/ubuntu/xmobile-v1/node_modules/next/dist/server/next-server.js:269:37)
    at async NextNodeServer.handleRequestImpl (/home/ubuntu/xmobile-v1/node_modules/next/dist/server/base-server.js:818:17)
    at async invokeRender (/home/ubuntu/xmobile-v1/node_modules/next/dist/server/lib/router-server.js:182:21)