### PR TITLE
Fix: locale issues

### DIFF
--- a/src/pages/components/Appbar.tsx
+++ b/src/pages/components/Appbar.tsx
@@ -132,8 +132,14 @@ export default function CustomAppBar({
   };
 
   useEffect(() => {
-    setSelectedLocale((prev) => getCookie(LOCALE_COOKIE_NAME) || prev);
-  }, []);
+    if (router.locale && router.locale !== router.defaultLocale) {
+      setSelectedLocale(router.locale);
+    } else {
+      setSelectedLocale(
+        getCookie(LOCALE_COOKIE_NAME) || router.defaultLocale || 'ru',
+      );
+    }
+  }, [router.locale, router.defaultLocale]);
 
   useEffect(() => {
     const handler = setTimeout(() => {

--- a/src/pages/privacy-policy.page.tsx
+++ b/src/pages/privacy-policy.page.tsx
@@ -12,14 +12,16 @@ import { useTranslations } from 'next-intl';
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   let messages = {};
-  let locale =
-    cookie.parse(context.req.headers.cookie ?? '')[LOCALE_COOKIE_NAME] ?? null;
+  const cookieLocale = cookie.parse(context.req.headers.cookie ?? '')[
+    LOCALE_COOKIE_NAME
+  ];
+  const locale =
+    context.locale !== context.defaultLocale
+      ? context.locale!
+      : cookieLocale ?? context.locale ?? 'ru';
 
   try {
-    if (locale == null) {
-      locale = 'ru'; // fallback
-    }
-    messages = (await import(`../i18n/${context.locale}.json`)).default;
+    messages = (await import(`../i18n/${locale}.json`)).default;
   } catch (error) {
     console.error(error);
   }

--- a/src/pages/support.page.tsx
+++ b/src/pages/support.page.tsx
@@ -25,14 +25,16 @@ const SUPPORT_PHONES = ['+99361004933', '+99371211717', '+99342230620'];
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   let messages = {};
-  let locale =
-    cookie.parse(context.req.headers.cookie ?? '')[LOCALE_COOKIE_NAME] ?? null;
+  const cookieLocale = cookie.parse(context.req.headers.cookie ?? '')[
+    LOCALE_COOKIE_NAME
+  ];
+  const locale =
+    context.locale !== context.defaultLocale
+      ? context.locale!
+      : cookieLocale ?? context.locale ?? 'ru';
 
   try {
-    if (locale == null) {
-      locale = 'ru';
-    }
-    messages = (await import(`../i18n/${context.locale}.json`)).default;
+    messages = (await import(`../i18n/${locale}.json`)).default;
   } catch (error) {
     console.error(error);
   }

--- a/src/pages/user/index.page.tsx
+++ b/src/pages/user/index.page.tsx
@@ -68,8 +68,14 @@ export default function Profile() {
   const isAdmin = user && ['SUPERUSER', 'ADMIN'].includes(user.grade);
 
   useEffect(() => {
-    setSelectedLocale((prev) => getCookie(LOCALE_COOKIE_NAME) || prev);
-  }, []);
+    if (router.locale && router.locale !== router.defaultLocale) {
+      setSelectedLocale(router.locale);
+    } else {
+      setSelectedLocale(
+        getCookie(LOCALE_COOKIE_NAME) || router.defaultLocale || 'ru',
+      );
+    }
+  }, [router.locale, router.defaultLocale]);
 
   const handleToggleLang = () => {
     setOpenLang(!openLang);

--- a/src/pages/user/sign_in_up.page.tsx
+++ b/src/pages/user/sign_in_up.page.tsx
@@ -4,18 +4,21 @@ import { useUserContext } from '@/pages/lib/UserContext';
 import { profileClasses } from '@/styles/classMaps/user/profile';
 import { colors, interClassname } from '@/styles/theme';
 import { Box, CardMedia, Link, Typography } from '@mui/material';
-import { GetStaticProps } from 'next';
+import { LOCALE_COOKIE_NAME } from '@/pages/lib/constants';
+import cookie from 'cookie';
+import { GetServerSideProps } from 'next';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
-// getStaticProps because translations are static
-export const getStaticProps = (async (context) => {
-  return {
-    props: {
-      messages: (await import(`../../i18n/${context.locale}.json`)).default,
-    },
-  };
-}) satisfies GetStaticProps<object>;
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const locale =
+    cookie.parse(context.req.headers.cookie ?? '')[LOCALE_COOKIE_NAME] ??
+    context.locale ??
+    'ru';
+  const messages = (await import(`../../i18n/${locale}.json`)).default;
+  return { props: { messages } };
+};
 
 export default function SignInUp() {
   const router = useRouter();

--- a/src/pages/user/sign_in_up.page.tsx
+++ b/src/pages/user/sign_in_up.page.tsx
@@ -3,7 +3,8 @@ import { usePlatform } from '@/pages/lib/PlatformContext';
 import { useUserContext } from '@/pages/lib/UserContext';
 import { profileClasses } from '@/styles/classMaps/user/profile';
 import { colors, interClassname } from '@/styles/theme';
-import { Box, CardMedia, Link, Typography } from '@mui/material';
+import { Box, CardMedia, Typography } from '@mui/material';
+import Link from 'next/link';
 import { LOCALE_COOKIE_NAME } from '@/pages/lib/constants';
 import cookie from 'cookie';
 import { GetServerSideProps } from 'next';
@@ -12,10 +13,13 @@ import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
+  const cookieLocale = cookie.parse(context.req.headers.cookie ?? '')[
+    LOCALE_COOKIE_NAME
+  ];
   const locale =
-    cookie.parse(context.req.headers.cookie ?? '')[LOCALE_COOKIE_NAME] ??
-    context.locale ??
-    'ru';
+    context.locale !== context.defaultLocale
+      ? context.locale!
+      : cookieLocale ?? context.locale ?? 'ru';
   const messages = (await import(`../../i18n/${locale}.json`)).default;
   return { props: { messages } };
 };

--- a/src/pages/user/signin.page.tsx
+++ b/src/pages/user/signin.page.tsx
@@ -17,18 +17,21 @@ import {
   Typography,
 } from '@mui/material';
 import { User } from '@prisma/client';
-import { GetStaticProps } from 'next';
+import { LOCALE_COOKIE_NAME } from '@/pages/lib/constants';
+import cookie from 'cookie';
+import { GetServerSideProps } from 'next';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-// getStaticProps because translations are static
-export const getStaticProps = (async (context) => {
-  return {
-    props: {
-      messages: (await import(`../../i18n/${context.locale}.json`)).default,
-    },
-  };
-}) satisfies GetStaticProps<object>;
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const locale =
+    cookie.parse(context.req.headers.cookie ?? '')[LOCALE_COOKIE_NAME] ??
+    context.locale ??
+    'ru';
+  const messages = (await import(`../../i18n/${locale}.json`)).default;
+  return { props: { messages } };
+};
 
 export default function Signin() {
   const { user, setUser, setAccessToken, isLoading } = useUserContext();

--- a/src/pages/user/signin.page.tsx
+++ b/src/pages/user/signin.page.tsx
@@ -11,11 +11,11 @@ import {
   CardMedia,
   IconButton,
   InputAdornment,
-  Link,
   Paper,
   TextField,
   Typography,
 } from '@mui/material';
+import Link from 'next/link';
 import { User } from '@prisma/client';
 import { LOCALE_COOKIE_NAME } from '@/pages/lib/constants';
 import cookie from 'cookie';
@@ -25,10 +25,13 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
+  const cookieLocale = cookie.parse(context.req.headers.cookie ?? '')[
+    LOCALE_COOKIE_NAME
+  ];
   const locale =
-    cookie.parse(context.req.headers.cookie ?? '')[LOCALE_COOKIE_NAME] ??
-    context.locale ??
-    'ru';
+    context.locale !== context.defaultLocale
+      ? context.locale!
+      : cookieLocale ?? context.locale ?? 'ru';
   const messages = (await import(`../../i18n/${locale}.json`)).default;
   return { props: { messages } };
 };

--- a/src/pages/user/signup.page.tsx
+++ b/src/pages/user/signup.page.tsx
@@ -18,20 +18,22 @@ import {
   Typography,
 } from '@mui/material';
 import { User } from '@prisma/client';
-import { GetStaticProps } from 'next';
+import { LOCALE_COOKIE_NAME } from '@/pages/lib/constants';
+import cookie from 'cookie';
+import { GetServerSideProps } from 'next';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
-// getStaticProps because translations are static
-export const getStaticProps = (async (context) => {
-  return {
-    props: {
-      messages: (await import(`../../i18n/${context.locale}.json`)).default,
-    },
-  };
-}) satisfies GetStaticProps<object>;
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const locale =
+    cookie.parse(context.req.headers.cookie ?? '')[LOCALE_COOKIE_NAME] ??
+    context.locale ??
+    'ru';
+  const messages = (await import(`../../i18n/${locale}.json`)).default;
+  return { props: { messages } };
+};
 
 export default function Signup() {
   const { user, setUser, setAccessToken, isLoading } = useUserContext();

--- a/src/pages/user/signup.page.tsx
+++ b/src/pages/user/signup.page.tsx
@@ -27,10 +27,13 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
+  const cookieLocale = cookie.parse(context.req.headers.cookie ?? '')[
+    LOCALE_COOKIE_NAME
+  ];
   const locale =
-    cookie.parse(context.req.headers.cookie ?? '')[LOCALE_COOKIE_NAME] ??
-    context.locale ??
-    'ru';
+    context.locale !== context.defaultLocale
+      ? context.locale!
+      : cookieLocale ?? context.locale ?? 'ru';
   const messages = (await import(`../../i18n/${locale}.json`)).default;
   return { props: { messages } };
 };


### PR DESCRIPTION
## Summary

  Fix locale selection to follow URL-first strategy across all pages, ensuring users see the correct language UI and messages based on their current path.

  ## Problem

  - Visiting `/ch/user/signin` loaded Russian (ru) messages due to cookie-first locale resolution
  - Language selector only read from cookie, ignoring the current URL path locale
  - Inconsistent behavior: some pages checked URL, others checked cookie first

  ## Solution

  **Unified locale resolution strategy:**
  1. **URL-first** (when on non-default locale path like `/ch/`, `/tk/`, etc.)
  2. **Cookie fallback** (when on default path like `/` or no locale segment)
  3. **Default fallback** (ru if neither URL nor cookie present)

  ### Changes

  | Component | Behavior |
  |-----------|----------|
  | Appbar language selector | Now checks `router.locale !== router.defaultLocale` first |
  | User profile language selector | Same URL-first logic |
  | Auth pages (signin, signup, sign_in_up) | `getServerSideProps` loads messages from URL-first locale |
  | Info pages (support, privacy-policy) | `getServerSideProps` locale for both UI messages and SEO metadata |
  | Navigation links | Fixed `sign_in_up.page.tsx` to use `next/link` (was MUI Link) |

  ## Testing

  - Visit `/ch/user/signin` → verifies Charjew locale loads
  - Visit `/tk/user/signup` → verifies Turkmen locale loads
  - Switch language in selector → updates URL and UI in sync
  - Visit root without locale → falls back to cookie if set