### PR TITLE
fix: resolve SEO blocking brand splash screen and hydration mismatches

### DIFF
--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -254,12 +254,13 @@ export default function App({ Component, pageProps }: AppProps) {
                               timeZone="Asia/Ashgabat"
                               messages={pageProps.messages}
                             >
-                              {isLoading && <Loader />}
-                              {showHardUpdateModal && (
+                              {showHardUpdateModal ? (
                                 <UpdateModal type="hard" />
-                              )}
-                              {!isLoading && !showHardUpdateModal && (
-                                <Component {...pageProps} />
+                              ) : (
+                                <>
+                                  <Component {...pageProps} />
+                                  {isLoading && <Loader />}
+                                </>
                               )}
                             </NextIntlClientProvider>
                           </PlatformContextProvider>

--- a/src/pages/components/Loader.tsx
+++ b/src/pages/components/Loader.tsx
@@ -2,7 +2,11 @@ import { Box, CardMedia } from '@mui/material';
 
 export default function Loader() {
   return (
-    <Box className="flex justify-center items-center h-full w-full">
+    <Box
+      // Splash sits above every MUI layer (appBar/drawer/modal/snackbar/tooltip)
+      sx={{ zIndex: (theme) => theme.zIndex.tooltip + 1 }}
+      className="fixed inset-0 flex justify-center items-center bg-white"
+    >
       <CardMedia
         component="img"
         src="/logo/xmobile-original-logo.jpeg"

--- a/src/pages/lib/PlatformContext.tsx
+++ b/src/pages/lib/PlatformContext.tsx
@@ -41,6 +41,11 @@ export default function PlatformContextProvider({
 export const usePlatform = (): Platform => {
   const context = useContext(PlatformContext);
   if (!context) {
+    if (process.env.NODE_ENV !== 'production') {
+      throw new Error(
+        'usePlatform must be used within <PlatformContextProvider />',
+      );
+    }
     return 'web';
   }
   return context.platform;

--- a/src/pages/lib/PlatformContext.tsx
+++ b/src/pages/lib/PlatformContext.tsx
@@ -1,6 +1,12 @@
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import { createContext, ReactNode, useContext } from 'react';
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 
 export type Platform = 'mobile' | 'web';
 
@@ -18,9 +24,12 @@ export default function PlatformContextProvider({
   children: ReactNode;
 }) {
   const theme = useTheme();
+  const isMobileQuery = useMediaQuery(theme.breakpoints.down('md'));
+  const [platform, setPlatform] = useState<Platform>('web');
 
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
-  const platform: Platform = isMobile ? 'mobile' : 'web';
+  useEffect(() => {
+    setPlatform(isMobileQuery ? 'mobile' : 'web');
+  }, [isMobileQuery]);
 
   return (
     <PlatformContext.Provider value={{ platform }}>
@@ -31,5 +40,8 @@ export default function PlatformContextProvider({
 
 export const usePlatform = (): Platform => {
   const context = useContext(PlatformContext);
+  if (!context) {
+    return 'web';
+  }
   return context.platform;
 };


### PR DESCRIPTION
## Description

This PR fixes SEO indexing and hydration issues.

### SEO Fix

The web loader previously blocked page content from rendering during SSR/SSG, resulting in incomplete server-generated HTML.

**Changes**
- **Splash no longer blocks SSR** (`_app.page.tsx`): the page `<Component>` always renders; the `<Loader>` is overlaid instead of replacing it. 
- **Splash renders as a true overlay** (`Loader.tsx`): `position: fixed` at `theme.zIndex.tooltip + 1` instead of an in-flow `h-full` block — covers the viewport for ~1s without pushing content out of flow or creating a phantom scroll region.

### Hydration Fix

Mobile platform detection caused client and server markup to differ during hydration.

**Changes**

* Moved platform detection in `PlatformContext.tsx` to `useEffect`.
* Ensured the initial client render matches the server-rendered `web` layout before switching to `mobile` after mount.


- Before .html mostly had footer and next generated page props, `__NEXT_DATA___` on main page
<img width="2524" height="1384" alt="Screenshot from 2026-06-04 22-48-03" src="https://github.com/user-attachments/assets/501c0dbf-9ae4-491a-9432-32a582824c8c" />
- After,  full html content (tags, MUI blocks, etc) 
<img width="2524" height="1384" alt="Screenshot from 2026-06-04 22-47-49" src="https://github.com/user-attachments/assets/1f2258f4-bac6-4baf-9848-1cde906daf86" />

Closes #367 
