### PR TITLE
FCM endpoint

### DIFF
--- a/src/lib/fcm/credential.ts
+++ b/src/lib/fcm/credential.ts
@@ -28,10 +28,7 @@ const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
  * OAuth scope *identifiers* embedded in the signed JWT — they are NOT network
  * calls, so the `www.googleapis.com` strings here never hit the SNI filter.
  */
-const SCOPES = [
-  'https://www.googleapis.com/auth/cloud-platform',
-  'https://www.googleapis.com/auth/firebase.messaging',
-].join(' ');
+const SCOPES = 'https://www.googleapis.com/auth/firebase.messaging';
 
 interface ServiceAccountJson {
   client_email: string;

--- a/src/lib/fcm/credential.ts
+++ b/src/lib/fcm/credential.ts
@@ -1,0 +1,139 @@
+import crypto from 'crypto';
+import * as admin from 'firebase-admin';
+
+/**
+ * Google's OAuth2 token endpoint.
+ *
+ * IMPORTANT (Turkmenistan deployment): the firebase-admin SDK's default
+ * credential (`admin.credential.cert()`) mints its access token at
+ * `https://www.googleapis.com/oauth2/v4/token` — a host hardcoded inside the
+ * transitive `gtoken` dependency. On the Telekom VM that hostname is blocked at
+ * TWO layers:
+ *   1. DNS is sinkholed (`www.googleapis.com` → 127.0.0.1), and
+ *   2. the upstream firewall drops TLS ClientHellos whose SNI is
+ *      `www.googleapis.com` (verified: the SAME Google IP completes the
+ *      handshake for SNI `oauth2.googleapis.com` but times out for
+ *      `www.googleapis.com`).
+ *
+ * `oauth2.googleapis.com` is Google's canonical modern token endpoint, passes
+ * the SNI filter from the VM, and is an accepted token endpoint / JWT audience
+ * for service-account assertions. So we mint the access token ourselves against
+ * it instead of relying on gtoken's hardcoded (blocked) host. See AGENTS.md for
+ * the network context.
+ */
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+
+/**
+ * Scopes firebase-admin normally requests for its server SDKs. These are plain
+ * OAuth scope *identifiers* embedded in the signed JWT — they are NOT network
+ * calls, so the `www.googleapis.com` strings here never hit the SNI filter.
+ */
+const SCOPES = [
+  'https://www.googleapis.com/auth/cloud-platform',
+  'https://www.googleapis.com/auth/firebase.messaging',
+].join(' ');
+
+interface ServiceAccountJson {
+  client_email: string;
+  private_key: string;
+}
+
+function base64url(input: Buffer | string): string {
+  return (typeof input === 'string' ? Buffer.from(input) : input)
+    .toString('base64')
+    .replace(/=+$/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function createSignedJwt(serviceAccount: ServiceAccountJson): string {
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: 'RS256', typ: 'JWT' };
+  const claims = {
+    iss: serviceAccount.client_email,
+    scope: SCOPES,
+    aud: GOOGLE_TOKEN_URL,
+    iat: now,
+    exp: now + 3600,
+  };
+
+  const signingInput = `${base64url(JSON.stringify(header))}.${base64url(
+    JSON.stringify(claims),
+  )}`;
+  const signature = crypto
+    .createSign('RSA-SHA256')
+    .update(signingInput)
+    .sign(serviceAccount.private_key);
+
+  return `${signingInput}.${base64url(signature)}`;
+}
+
+/**
+ * Builds a firebase-admin Credential that fetches its OAuth2 access token from
+ * `oauth2.googleapis.com` (reachable from the TM VM) instead of the blocked
+ * `www.googleapis.com` used by the default `admin.credential.cert()`.
+ *
+ * The signed-JWT bearer flow is implemented with Node's built-in `crypto` so we
+ * add no new dependency (per AGENTS.md: prefer VM-local, self-contained code).
+ */
+export function createOAuth2GoogleapisCredential(
+  serviceAccount: ServiceAccountJson,
+): admin.credential.Credential {
+  // Token cache: firebase-admin caches tokens internally, but we also guard
+  // here so a blocked/slow path can never trigger more than one mint per hour.
+  let cached: {
+    access_token: string;
+    expires_in: number;
+    mintedAtMs: number;
+  } | null = null;
+
+  return {
+    async getAccessToken() {
+      // Reuse until 60s before expiry.
+      if (
+        cached &&
+        Date.now() < cached.mintedAtMs + (cached.expires_in - 60) * 1000
+      ) {
+        return {
+          access_token: cached.access_token,
+          expires_in: cached.expires_in,
+        };
+      }
+
+      const assertion = createSignedJwt(serviceAccount);
+      const body = new URLSearchParams({
+        grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+        assertion,
+      });
+
+      const response = await fetch(GOOGLE_TOKEN_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+      });
+
+      if (!response.ok) {
+        const detail = await response.text().catch(() => '');
+        throw new Error(
+          `[FCM Service] OAuth token request to ${GOOGLE_TOKEN_URL} failed: ${response.status} ${detail}`,
+        );
+      }
+
+      const data = (await response.json()) as {
+        access_token: string;
+        expires_in: number;
+      };
+
+      cached = {
+        access_token: data.access_token,
+        expires_in: data.expires_in,
+        mintedAtMs: Date.now(),
+      };
+
+      return {
+        access_token: data.access_token,
+        expires_in: data.expires_in,
+      };
+    },
+  };
+}

--- a/src/lib/fcm/fcmService.ts
+++ b/src/lib/fcm/fcmService.ts
@@ -2,6 +2,7 @@ import dbClient from '@/lib/dbClient';
 import { NotificationType } from '@prisma/client';
 import * as admin from 'firebase-admin';
 import fs from 'fs';
+import { createOAuth2GoogleapisCredential } from './credential';
 import { FCMNotificationPayload, FCMSendResult } from './types';
 
 let firebaseApp: admin.app.App | null = null;
@@ -37,8 +38,16 @@ function initializeOrGetFirebaseApp(): admin.app.App {
     const serviceAccountData = fs.readFileSync(credentialsPath, 'utf8');
     const serviceAccount = JSON.parse(serviceAccountData);
 
+    // NOTE: we deliberately do NOT use `admin.credential.cert()`. Its token
+    // minting goes to `www.googleapis.com`, which is blocked (DNS sinkhole +
+    // SNI filtering) on the Telekom VM. Our credential mints at
+    // `oauth2.googleapis.com` instead. Because a custom credential does not
+    // carry the project id, we pass `projectId` explicitly so the messaging
+    // send URL (fcm.googleapis.com/v1/projects/<id>/messages:send) is built.
+    // See src/lib/fcm/credential.ts for the full network context.
     firebaseApp = admin.initializeApp({
-      credential: admin.credential.cert(serviceAccount),
+      credential: createOAuth2GoogleapisCredential(serviceAccount),
+      projectId: serviceAccount.project_id,
     });
 
     console.log('[FCM Service] Firebase Admin SDK initialized successfully');


### PR DESCRIPTION
**Problem**

All FCM push sends from the production VM fail at credential setup:

▎ Credential ... failed to fetch a valid Google OAuth2 access token ... Hostname/IP does not match certificate's altnames

Root cause is network-level, not code: the Telekom (Turkmenistan) VM blocks www.googleapis.com at two layers — DNS is sinkholed to 127.0.0.1, and the upstream firewall drops TLS ClientHellos whose SNI is www.googleapis.com. That host is exactly where the Firebase Admin SDK mints its OAuth2 token (hardcoded in the transitive gtoken dep), so every send dies before reaching FCM. Verified that the same Google IP completes the handshake for SNI oauth2.googleapis.com but times out for www.googleapis.com; fcm.googleapis.com and APNs are both reachable.

**Fix**

Replace admin.credential.cert() with a small custom credential that mints the access token at Google's canonical modern endpoint oauth2.googleapis.com/token (reachable, passes the SNI filter, accepted token endpoint/JWT audience for service-account assertions).

- New src/lib/fcm/credential.ts — signs the service-account JWT with Node's built-in crypto (no new dependency), POSTs to oauth2.googleapis.com, caches the token until ~60s before expiry. Requests only the firebase.messaging scope (least privilege; this app uses firebase-admin for messaging only).
- src/lib/fcm/fcmService.ts — use the new credential and pass projectId explicitly (a custom credential doesn't carry it; the messages:send URL needs it).