### PR TITLE
feat: banners db changes

### DIFF
--- a/prisma/migrations/20260628102429_promo_banner/migration.sql
+++ b/prisma/migrations/20260628102429_promo_banner/migration.sql
@@ -1,0 +1,25 @@
+-- CreateEnum
+CREATE TYPE "BannerRedirectType" AS ENUM ('CATEGORY', 'PRODUCT');
+
+-- CreateTable
+CREATE TABLE "PromoBanner" (
+    "id" TEXT NOT NULL,
+    "imgUrls" JSONB NOT NULL,
+    "redirectType" "BannerRedirectType",
+    "redirectId" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "startsAt" TIMESTAMP(3),
+    "endsAt" TIMESTAMP(3),
+    "deletedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PromoBanner_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "PromoBanner_deletedAt_idx" ON "PromoBanner"("deletedAt");
+
+-- CreateIndex
+CREATE INDEX "PromoBanner_isActive_sortOrder_idx" ON "PromoBanner"("isActive", "sortOrder");

--- a/prisma/migrations/20260628102429_promo_banner/migration.sql
+++ b/prisma/migrations/20260628102429_promo_banner/migration.sql
@@ -19,7 +19,4 @@ CREATE TABLE "PromoBanner" (
 );
 
 -- CreateIndex
-CREATE INDEX "PromoBanner_deletedAt_idx" ON "PromoBanner"("deletedAt");
-
--- CreateIndex
 CREATE INDEX "PromoBanner_isActive_sortOrder_idx" ON "PromoBanner"("isActive", "sortOrder");

--- a/prisma/migrations/20260628102429_promo_banner/migration.sql
+++ b/prisma/migrations/20260628102429_promo_banner/migration.sql
@@ -1,12 +1,9 @@
--- CreateEnum
-CREATE TYPE "BannerRedirectType" AS ENUM ('CATEGORY', 'PRODUCT');
-
 -- CreateTable
 CREATE TABLE "PromoBanner" (
     "id" TEXT NOT NULL,
     "imgUrls" JSONB NOT NULL,
-    "redirectType" "BannerRedirectType",
-    "redirectId" TEXT,
+    "redirectProductId" TEXT,
+    "redirectCategoryId" TEXT,
     "isActive" BOOLEAN NOT NULL DEFAULT true,
     "sortOrder" INTEGER NOT NULL DEFAULT 0,
     "startsAt" TIMESTAMP(3),
@@ -20,3 +17,9 @@ CREATE TABLE "PromoBanner" (
 
 -- CreateIndex
 CREATE INDEX "PromoBanner_isActive_sortOrder_idx" ON "PromoBanner"("isActive", "sortOrder");
+
+-- AddForeignKey
+ALTER TABLE "PromoBanner" ADD CONSTRAINT "PromoBanner_redirectProductId_fkey" FOREIGN KEY ("redirectProductId") REFERENCES "Product"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PromoBanner" ADD CONSTRAINT "PromoBanner_redirectCategoryId_fkey" FOREIGN KEY ("redirectCategoryId") REFERENCES "Category"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -84,6 +84,8 @@ model Category {
 
   imgUrl                          String?
 
+  promoBanners                    PromoBanner[]
+
   deletedAt                       DateTime?
 
   popular                         Boolean    @default(false)
@@ -95,34 +97,30 @@ model Category {
   @@index([predecessorId, sortOrder])
 }
 
-
-enum BannerRedirectType {
-  CATEGORY
-  PRODUCT
-}
-
 model PromoBanner {
-  id              String              @id @default(uuid())
+  id                  String              @id @default(uuid())
 
   /// Map of locale -> stored image path/URL, e.g. { "default": "...", "en": "...", "ru": "..." }.
   /// `default` is always present; per-locale keys are optional overrides.
-  imgUrls         Json
+  imgUrls             Json
 
-  /// Resolved to /category/[slug] or /product/[slug] at read time.
-  redirectType    BannerRedirectType?
-  redirectId      String?
+  redirectProductId   String?           
+  redirectProduct     Product?            @relation(fields: [redirectProductId], references: [id], onDelete: SetNull)
 
-  isActive        Boolean             @default(true)
+  redirectCategoryId  String?           
+  redirectCategory    Category?           @relation(fields: [redirectCategoryId], references: [id], onDelete: SetNull)
 
-  sortOrder       Int                 @default(0)
+  isActive            Boolean             @default(true)
 
-  startsAt        DateTime?
-  endsAt          DateTime?
+  sortOrder           Int                 @default(0)
 
-  deletedAt       DateTime?
+  startsAt            DateTime?
+  endsAt              DateTime?
 
-  createdAt       DateTime            @default(now())
-  updatedAt       DateTime            @updatedAt
+  deletedAt           DateTime?
+
+  createdAt           DateTime            @default(now())
+  updatedAt           DateTime            @updatedAt
 
   @@index([isActive, sortOrder])
 }
@@ -151,6 +149,8 @@ model Product {
 
   isOutOfStock    Boolean     @default(false)
   colors          Color[]
+
+  promoBanners    PromoBanner[]
 
   deletedAt       DateTime?
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -108,16 +108,14 @@ model PromoBanner {
   /// `default` is always present; per-locale keys are optional overrides.
   imgUrls         Json
 
-  /// Optional internal deep-link target. Resolved to /category/[slug] or /product/[slug] at read time.
+  /// Resolved to /category/[slug] or /product/[slug] at read time.
   redirectType    BannerRedirectType?
   redirectId      String?
 
   isActive        Boolean             @default(true)
 
-  /// Display order in the carousel. Lower values appear first.
   sortOrder       Int                 @default(0)
 
-  /// Optional scheduling window. Null means no bound on that side.
   startsAt        DateTime?
   endsAt          DateTime?
 
@@ -126,7 +124,6 @@ model PromoBanner {
   createdAt       DateTime            @default(now())
   updatedAt       DateTime            @updatedAt
 
-  @@index([deletedAt])
   @@index([isActive, sortOrder])
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -96,6 +96,40 @@ model Category {
 }
 
 
+enum BannerRedirectType {
+  CATEGORY
+  PRODUCT
+}
+
+model PromoBanner {
+  id              String              @id @default(uuid())
+
+  /// Map of locale -> stored image path/URL, e.g. { "default": "...", "en": "...", "ru": "..." }.
+  /// `default` is always present; per-locale keys are optional overrides.
+  imgUrls         Json
+
+  /// Optional internal deep-link target. Resolved to /category/[slug] or /product/[slug] at read time.
+  redirectType    BannerRedirectType?
+  redirectId      String?
+
+  isActive        Boolean             @default(true)
+
+  /// Display order in the carousel. Lower values appear first.
+  sortOrder       Int                 @default(0)
+
+  /// Optional scheduling window. Null means no bound on that side.
+  startsAt        DateTime?
+  endsAt          DateTime?
+
+  deletedAt       DateTime?
+
+  createdAt       DateTime            @default(now())
+  updatedAt       DateTime            @updatedAt
+
+  @@index([deletedAt])
+  @@index([isActive, sortOrder])
+}
+
 model Product {
   id              String      @id @default(uuid())
   slug            String      @unique


### PR DESCRIPTION
**DB changes for promotional banners**

- ImgUrls made json to make them localized.
- sortOrder defines which banner comes when
- startsAt and endsAt are for campaigns we migth make for some time (like 20% discount till the end of the month)
- redirectType and redirectId for redirecting when banner is clicked. Iphone 17 pro banner, clicking it redrects to detail page
- isActive to stop the banner for time, instead of deleting 