### PR TITLE
feat: fcm retry notification db changes

### DIFF
--- a/prisma/migrations/20260702095913_push_retry_notifications/migration.sql
+++ b/prisma/migrations/20260702095913_push_retry_notifications/migration.sql
@@ -1,0 +1,29 @@
+-- CreateEnum
+CREATE TYPE "NotificationDeliveryStatus" AS ENUM ('PENDING', 'SENT', 'FAILED');
+
+-- AlterTable
+ALTER TABLE "InAppNotification" ADD COLUMN     "deliveryStatus" "NotificationDeliveryStatus" NOT NULL DEFAULT 'PENDING',
+ADD COLUMN     "lastAttemptAt" TIMESTAMP(3),
+ADD COLUMN     "lastError" TEXT,
+ADD COLUMN     "nextRetryAt" TIMESTAMP(3),
+ADD COLUMN     "retryCount" INTEGER NOT NULL DEFAULT 0;
+
+-- Backfill: rows that predate delivery tracking were already handled by the original
+-- fire-and-forget send. Mark them SENT so the retry job never re-sends history.
+UPDATE "InAppNotification" SET "deliveryStatus" = 'SENT' WHERE "deliveryStatus" = 'PENDING';
+
+-- CreateTable
+CREATE TABLE "PushRetryConfig" (
+    "id" INTEGER NOT NULL DEFAULT 1,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "maxRetries" INTEGER NOT NULL DEFAULT 3,
+    "baseDelaySec" INTEGER NOT NULL DEFAULT 30,
+    "backoffMultiplier" DOUBLE PRECISION NOT NULL DEFAULT 2.0,
+    "maxDelaySec" INTEGER NOT NULL DEFAULT 3600,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PushRetryConfig_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "InAppNotification_deliveryStatus_nextRetryAt_idx" ON "InAppNotification"("deliveryStatus", "nextRetryAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -282,6 +282,22 @@ enum NotificationType {
   ORDER_STATUS_UPDATE
 }
 
+enum NotificationDeliveryStatus {
+  PENDING // needs (re)send — created-but-unsent or a failed attempt
+  SENT 
+  FAILED // retries exhausted — gave up
+}
+
+model PushRetryConfig {
+  id                Int      @id @default(1)
+  enabled           Boolean  @default(true)
+  maxRetries        Int      @default(3)
+  baseDelaySec      Int      @default(30)
+  backoffMultiplier Float    @default(2.0)
+  maxDelaySec       Int      @default(3600)
+  updatedAt         DateTime @updatedAt
+}
+
 model InAppNotification {
   id          String            @id @default(uuid())
   
@@ -306,11 +322,18 @@ model InAppNotification {
   createdAt   DateTime          @default(now())
   updatedAt   DateTime          @updatedAt
   readAt      DateTime?         // When notification was read
-  
+
+  deliveryStatus NotificationDeliveryStatus @default(PENDING)
+  retryCount     Int                        @default(0)
+  nextRetryAt    DateTime?
+  lastAttemptAt  DateTime?
+  lastError      String?
+
   @@index([userId, isRead])
   @@index([userId, createdAt])
   @@index([sessionId])
   @@index([orderId])
+  @@index([deliveryStatus, nextRetryAt])
 }
 
 model FCMToken {


### PR DESCRIPTION
Code changes in #384 

Db changes of fcm retry notifcaiton.

**Summary**

- created PushRetryConfig, its gonna be one row table such as appVersion. which will allow us to manually edit retry logic through superuser access.
-  created NotificationDeliveryStatus enum with FAILED (even our retries were not successfull), PENDING (havent been sent, and retrying) and SENT (fcm token sent amount is increased, no errors appeared during the process)