### PR TITLE
feat: retry daily backup if fails

### DIFF
--- a/.github/workflows/retry-failed-backup.yml
+++ b/.github/workflows/retry-failed-backup.yml
@@ -1,0 +1,26 @@
+# Auto-retry: if Daily Backup to Drive fails, rerun only the failed jobs (via GitHub's
+# rerun-failed-jobs API), capped at one automatic retry so a genuinely broken VM doesn't loop.
+name: Retry Failed Backup Jobs
+
+on:
+  workflow_run:
+    workflows: ["Daily Backup to Drive"]
+    types: [completed]
+
+permissions:
+  actions: write
+
+jobs:
+  retry:
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt < 2
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Re-run only the failed jobs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api --method POST \
+            "/repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/rerun-failed-jobs"


### PR DESCRIPTION
New workflow which runs automatically if Daily Backup to Drive workflow ever fails. This workflow retries only failed jobs