### PR TITLE
Ensure Mobile Device Token Registration

### DIFF
--- a/src/pages/api/fcm/token.page.ts
+++ b/src/pages/api/fcm/token.page.ts
@@ -4,6 +4,7 @@ import withAuth, {
   AuthenticatedRequest,
 } from '@/pages/api/utils/authMiddleware';
 import { ResponseApi } from '@/pages/lib/types';
+import { Prisma } from '@prisma/client';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { z } from 'zod';
 
@@ -17,6 +18,19 @@ const RegisterTokenSchema = z.object({
 const DeleteTokenSchema = z.object({
   token: z.string().min(1, 'Token is required'),
 });
+
+// Devices registered via the app's WebView bridge are tagged `APP:...`
+// (see getDeviceInfo in fcmClient.ts); everything else is a browser subscription.
+const isMobileDevice = (deviceInfo: string) => deviceInfo.startsWith('APP:');
+
+function isDeviceInfoUniqueViolation(error: unknown): boolean {
+  return (
+    error instanceof Prisma.PrismaClientKnownRequestError &&
+    error.code === 'P2002' &&
+    (error.meta?.target as string[] | undefined)?.includes('deviceInfo') ===
+      true
+  );
+}
 
 async function handler(req: NextApiRequest, res: NextApiResponse<ResponseApi>) {
   addCors(res);
@@ -89,12 +103,45 @@ async function handler(req: NextApiRequest, res: NextApiResponse<ResponseApi>) {
       }
 
       // SCENARIO 3: Token doesn't exist, DeviceInfo doesn't exist → CREATE
-      // Use upsert on token to safely handle concurrent requests (TOCTOU race condition)
-      await dbClient.fCMToken.upsert({
-        where: { token },
-        update: { deviceInfo, userId },
-        create: { userId, token, deviceInfo },
-      });
+      // Mobile app push takes priority over browser push: a user shouldn't get
+      // the same notification twice (once on the phone app, once in the browser).
+      if (isMobileDevice(deviceInfo)) {
+        // New app subscription overrides any browser subscriptions for this user.
+        await dbClient.fCMToken.deleteMany({
+          where: { userId, NOT: { deviceInfo: { startsWith: 'APP:' } } },
+        });
+      } else {
+        const hasMobileDevice = await dbClient.fCMToken.findFirst({
+          where: { userId, deviceInfo: { startsWith: 'APP:' } },
+        });
+        if (hasMobileDevice) {
+          // User already gets push via the app; silently skip the browser subscription.
+          return res.status(200).json({
+            success: true,
+            message: 'Mobile app subscription already active for this user',
+          });
+        }
+      }
+
+      try {
+        // Use upsert on token to safely handle concurrent requests (TOCTOU race condition)
+        await dbClient.fCMToken.upsert({
+          where: { token },
+          update: { deviceInfo, userId },
+          create: { userId, token, deviceInfo },
+        });
+      } catch (error) {
+        if (!isDeviceInfoUniqueViolation(error)) {
+          throw error;
+        }
+        // Lost the race: a concurrent request just registered this deviceInfo
+        // (e.g. duplicate registration calls firing back-to-back). Converge on
+        // the same outcome as the "deviceInfo already exists" path above.
+        await dbClient.fCMToken.update({
+          where: { deviceInfo },
+          data: { token, userId },
+        });
+      }
 
       return res.status(201).json({
         success: true,

--- a/tests/integration/fcm-token.integration.test.ts
+++ b/tests/integration/fcm-token.integration.test.ts
@@ -221,6 +221,82 @@ describe('FCM token API (integration)', () => {
     expect(res._getStatusCode()).toBe(400);
   });
 
+  it('browser subscription is silently skipped when a mobile device is already registered', async () => {
+    const session = await signupTestUser('fcm-pri-a');
+    const handler = (await import('@/pages/api/fcm/token.page')).default;
+    const appDevice = `APP:${Date.now()}`;
+    const webDevice = `WEB:${Date.now()}`;
+
+    const app = createMocks({
+      method: 'POST',
+      url: '/api/fcm/token',
+      headers: { authorization: `Bearer ${session.accessToken}` },
+      body: { token: `app-tok-${Date.now()}`, deviceInfo: appDevice },
+    });
+    await handler(
+      app.req as unknown as NextApiRequest,
+      app.res as unknown as NextApiResponse,
+    );
+    expect(app.res._getStatusCode()).toBe(201);
+
+    const web = createMocks({
+      method: 'POST',
+      url: '/api/fcm/token',
+      headers: { authorization: `Bearer ${session.accessToken}` },
+      body: { token: `web-tok-${Date.now()}`, deviceInfo: webDevice },
+    });
+    await handler(
+      web.req as unknown as NextApiRequest,
+      web.res as unknown as NextApiResponse,
+    );
+    expect(web.res._getStatusCode()).toBe(200);
+
+    const rows = await prisma.fCMToken.findMany({
+      where: { userId: session.userId },
+    });
+    expect(rows.map((r) => r.deviceInfo)).toEqual([appDevice]);
+
+    await prisma.fCMToken.deleteMany({ where: { userId: session.userId } });
+  });
+
+  it('mobile subscription overrides an existing browser subscription for the same user', async () => {
+    const session = await signupTestUser('fcm-pri-b');
+    const handler = (await import('@/pages/api/fcm/token.page')).default;
+    const webDevice = `WEB:${Date.now()}`;
+    const appDevice = `APP:${Date.now()}`;
+
+    const web = createMocks({
+      method: 'POST',
+      url: '/api/fcm/token',
+      headers: { authorization: `Bearer ${session.accessToken}` },
+      body: { token: `web-tok-${Date.now()}`, deviceInfo: webDevice },
+    });
+    await handler(
+      web.req as unknown as NextApiRequest,
+      web.res as unknown as NextApiResponse,
+    );
+    expect(web.res._getStatusCode()).toBe(201);
+
+    const app = createMocks({
+      method: 'POST',
+      url: '/api/fcm/token',
+      headers: { authorization: `Bearer ${session.accessToken}` },
+      body: { token: `app-tok-${Date.now()}`, deviceInfo: appDevice },
+    });
+    await handler(
+      app.req as unknown as NextApiRequest,
+      app.res as unknown as NextApiResponse,
+    );
+    expect(app.res._getStatusCode()).toBe(201);
+
+    const rows = await prisma.fCMToken.findMany({
+      where: { userId: session.userId },
+    });
+    expect(rows.map((r) => r.deviceInfo)).toEqual([appDevice]);
+
+    await prisma.fCMToken.deleteMany({ where: { userId: session.userId } });
+  });
+
   it('DELETE returns 404 for unknown token', async () => {
     const session = await signupTestUser('fcm-404');
     const handler = (await import('@/pages/api/fcm/token.page')).default;


### PR DESCRIPTION
**Summary**

- Fix a race condition in POST /api/fcm/token: concurrent registration requests for a new, identical deviceInfo could both pass the existence check and then race on insert, crashing with Unique constraint failed on the fields: (deviceInfo). Now caught and converged onto an update.
- Add mobile-over-browser push priority: a new browser (WEB:) subscription is silently skipped if the user already has an app (APP:) subscription; a new app subscription overrides (deletes) any existing browser subscriptions for that user, so a phone doesn't get the same notification twice