### PR TITLE
SEO: single-locale ?locale= catalog API + server-rendered catalog pages

### DIFF
--- a/src/pages/api/category.page.ts
+++ b/src/pages/api/category.page.ts
@@ -13,8 +13,9 @@ import {
   POPULAR_CATEGORIES_SECTION_MAX,
   POPULAR_ROOT_LIMIT_CODE,
 } from '@/pages/lib/popularCategoriesLayout';
+import { localeOptions } from '@/pages/lib/constants';
 import { ExtendedCategory, ResponseApi } from '@/pages/lib/types';
-import { slugify } from '@/pages/lib/utils';
+import { sanitizeCategoryLocale, slugify } from '@/pages/lib/utils';
 import { Category } from '@prisma/client';
 import fs from 'fs';
 import multiparty from 'multiparty';
@@ -111,7 +112,14 @@ async function recursivelyGetCategories(
 async function handleGetCategory(query: {
   categoryId?: string;
   categorySlug?: string;
+  locale?: string | string[];
 }): Promise<{ resp: ResponseApi; status: number }> {
+  // Opt-in response localization: without a valid `locale`, responses keep the
+  // raw multi-locale JSON blobs (admin edit flows depend on receiving them).
+  const activeLocale =
+    typeof query.locale === 'string' && localeOptions.includes(query.locale)
+      ? query.locale
+      : undefined;
   if (query.categoryId == null && query.categorySlug == null) {
     const categories = await dbClient.category.findMany({
       where: {
@@ -121,13 +129,32 @@ async function handleGetCategory(query: {
       orderBy: categorySiblingOrderBy,
     });
     const nestedCategories = await recursivelyGetCategories(categories);
-    return { resp: { success: true, data: nestedCategories }, status: 200 };
+    return {
+      resp: {
+        success: true,
+        data: activeLocale
+          ? nestedCategories.map((cat) =>
+              sanitizeCategoryLocale(cat, activeLocale),
+            )
+          : nestedCategories,
+      },
+      status: 200,
+    };
   }
   const category = await getCategory(
     query.categoryId as string,
     query.categorySlug as string,
   );
-  return { resp: { success: true, data: category }, status: 200 };
+  return {
+    resp: {
+      success: true,
+      data:
+        activeLocale && category
+          ? sanitizeCategoryLocale(category, activeLocale)
+          : category,
+    },
+    status: 200,
+  };
 }
 
 async function handlePostCategory(req: NextApiRequest) {

--- a/src/pages/api/product/index.page.ts
+++ b/src/pages/api/product/index.page.ts
@@ -9,10 +9,15 @@ import {
   IMG_COMPRESSION_MIN_QUALITY,
   IMG_COMPRESSION_OPTIONS,
   SORT_OPTIONS,
+  localeOptions,
 } from '@/pages/lib/constants';
 import { ExtendedProduct, ResponseApi, SortOption } from '@/pages/lib/types';
 import { parseVariantTag } from '@/pages/product/utils';
-import { slugify } from '@/pages/lib/utils';
+import {
+  sanitizeProductLocale,
+  sanitizeProductsLocale,
+  slugify,
+} from '@/pages/lib/utils';
 import { Prisma, Product } from '@prisma/client';
 import fs from 'fs';
 import multiparty from 'multiparty';
@@ -295,6 +300,7 @@ async function handleGetProduct(query: {
   minPrice?: string;
   maxPrice?: string;
   sortBy?: SortOption;
+  locale?: string | string[];
 }): Promise<{ resp: ResponseApi; status: number }> {
   const {
     searchKeyword,
@@ -308,7 +314,14 @@ async function handleGetProduct(query: {
     minPrice,
     maxPrice,
     sortBy,
+    locale,
   } = query;
+  // Opt-in response localization: without a valid `locale`, responses keep the
+  // raw multi-locale JSON blobs (admin edit flows depend on receiving them).
+  const activeLocale =
+    typeof locale === 'string' && localeOptions.includes(locale)
+      ? locale
+      : undefined;
   const parsedPage = parseInt(page || '1', 10);
   const skip = (parsedPage - 1) * productsPerPage;
 
@@ -347,7 +360,15 @@ async function handleGetProduct(query: {
       };
     }
 
-    return { resp: { success: true, data: product }, status: 200 };
+    return {
+      resp: {
+        success: true,
+        data: activeLocale
+          ? sanitizeProductLocale(product, activeLocale)
+          : product,
+      },
+      status: 200,
+    };
   }
 
   const where: Prisma.ProductWhereInput = { ...whereActiveProduct };
@@ -456,7 +477,12 @@ async function handleGetProduct(query: {
   );
 
   return {
-    resp: { success: true, data: productsWithDisplayPrice },
+    resp: {
+      success: true,
+      data: activeLocale
+        ? sanitizeProductsLocale(productsWithDisplayPrice, activeLocale)
+        : productsWithDisplayPrice,
+    },
     status: 200,
   };
 }

--- a/src/pages/category/[slug].page.tsx
+++ b/src/pages/category/[slug].page.tsx
@@ -109,10 +109,12 @@ export const getStaticProps: GetStaticProps = async ({
       }
     }
 
-    // Fetch the specific category
+    // Fetch the specific category, localized to this route's locale
     const { success, data: categoryData }: ResponseApi<ExtendedCategory> =
       await (
-        await fetch(`${BASE_URL}/api/category?categorySlug=${categorySlug}`)
+        await fetch(
+          `${BASE_URL}/api/category?categorySlug=${categorySlug}&locale=${locale}`,
+        )
       ).json();
 
     if (!success || !categoryData) {
@@ -126,7 +128,7 @@ export const getStaticProps: GetStaticProps = async ({
       success: allSuccess,
       data: allCategories,
     }: ResponseApi<ExtendedCategory[]> = await (
-      await fetch(`${BASE_URL}/api/category`)
+      await fetch(`${BASE_URL}/api/category?locale=${locale}`)
     ).json();
 
     let parentCategory: ExtendedCategory | null = null;

--- a/src/pages/components/ProductGridContent.tsx
+++ b/src/pages/components/ProductGridContent.tsx
@@ -52,8 +52,7 @@ interface ProductGridContentProps {
   landingCategoryId?: string;
   category?: ExtendedCategory | null;
   categoryPath?: ExtendedCategory[];
-  // Server-fetched first page, so crawlers see real product links on wave one
-  // instead of the skeleton (see docs/seo-todos.md #10).
+  // Server-fetched first page so product links are in the SSR HTML, not the skeleton.
   initialProducts?: Product[];
 }
 
@@ -275,10 +274,8 @@ export default function ProductGridContent({
     titleText = t('searchResultsFor', { keyword: searchKeyword });
   }
 
-  // Context products start empty and get reset to [] on every mount/filter
-  // change (see the fetch effect above), so fall back to the server-fetched
-  // first page while that round-trip is in flight — this is what keeps
-  // product links present in the raw SSR HTML instead of only the skeleton.
+  // products resets to [] on every fetch, so fall back to the seeded first
+  // page to keep links in the SSR HTML.
   const displayProducts =
     products.length > 0 ? products : initialProducts ?? [];
 

--- a/src/pages/components/ProductGridContent.tsx
+++ b/src/pages/components/ProductGridContent.tsx
@@ -263,7 +263,10 @@ export default function ProductGridContent({
     }
   };
 
-  if (!router.isReady) return null;
+  // The /product browse page reads its category from the URL query (client-only,
+  // needs router.isReady). A landing page gets landingCategoryId as a prop, so it
+  // can render its seeded grid during SSR for indexing.
+  if (!landingCategoryId && !router.isReady) return null;
 
   let titleText = t('allProducts') || 'All Products';
   if (category) {

--- a/src/pages/components/ProductGridContent.tsx
+++ b/src/pages/components/ProductGridContent.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/pages/lib/types';
 import { useUserContext } from '@/pages/lib/UserContext';
 import { parseName } from '@/pages/lib/utils';
+import { Product } from '@prisma/client';
 import { homePageClasses } from '@/styles/classMaps';
 import { appbarClasses } from '@/styles/classMaps/components/appbar';
 import { productIndexPageClasses } from '@/styles/classMaps/product';
@@ -51,14 +52,19 @@ interface ProductGridContentProps {
   landingCategoryId?: string;
   category?: ExtendedCategory | null;
   categoryPath?: ExtendedCategory[];
+  // Server-fetched first page, so crawlers see real product links on wave one
+  // instead of the skeleton (see docs/seo-todos.md #10).
+  initialProducts?: Product[];
 }
 
 export default function ProductGridContent({
   landingCategoryId,
   category,
   categoryPath = [],
+  initialProducts,
 }: ProductGridContentProps) {
-  const [isLoading, setIsLoading] = useState(true);
+  const hasInitialProducts = (initialProducts?.length ?? 0) > 0;
+  const [isLoading, setIsLoading] = useState(!hasInitialProducts);
   const [hasMore, setHasMore] = useState(true);
   const [page, setPage] = useState(0);
   const { categories: allCategories } = useCategoryContext();
@@ -152,6 +158,7 @@ export default function ProductGridContent({
           minPrice: filters.minPrice,
           maxPrice: filters.maxPrice,
           sortBy: filters.sortBy,
+          locale: router.locale,
         };
 
         if (searchKeyword) {
@@ -201,6 +208,7 @@ export default function ProductGridContent({
         minPrice: filters.minPrice,
         maxPrice: filters.maxPrice,
         sortBy: filters.sortBy,
+        locale: router.locale,
       };
 
       if (searchKeyword) {
@@ -263,6 +271,13 @@ export default function ProductGridContent({
   } else if (searchKeyword) {
     titleText = t('searchResultsFor', { keyword: searchKeyword });
   }
+
+  // Context products start empty and get reset to [] on every mount/filter
+  // change (see the fetch effect above), so fall back to the server-fetched
+  // first page while that round-trip is in flight — this is what keeps
+  // product links present in the raw SSR HTML instead of only the skeleton.
+  const displayProducts =
+    products.length > 0 ? products : initialProducts ?? [];
 
   return (
     <Box>
@@ -410,7 +425,7 @@ export default function ProductGridContent({
                   </Box>
                 )}
               </Box>
-              {isLoading && products.length === 0 ? (
+              {isLoading && displayProducts.length === 0 ? (
                 <ProductGridSkeleton count={8} />
               ) : (
                 <Box className="flex flex-wrap w-full">
@@ -425,7 +440,7 @@ export default function ProductGridContent({
                       }
                     />
                   )}
-                  {products.map((product, idx) => (
+                  {displayProducts.map((product, idx) => (
                     <ProductCard
                       product={product}
                       key={idx}

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -146,6 +146,19 @@ export const getServerSideProps: GetServerSideProps = (async (context) => {
     console.error('Failed to load promo banners:', error);
   }
 
+  // Fetch the first page of products server-side so their links are present
+  // in the raw HTML on wave one, instead of only appearing after the
+  // client-side fetch effect below (see docs/seo-todos.md #10/#368).
+  let initialProducts: Product[] = [];
+  try {
+    initialProducts = await fetchProducts({
+      page: 1,
+      locale: routeLocale ?? finalLocale,
+    });
+  } catch (error) {
+    console.error('Failed to load initial products:', error);
+  }
+
   return {
     props: {
       locale:
@@ -153,17 +166,20 @@ export const getServerSideProps: GetServerSideProps = (async (context) => {
       messages,
       seoData,
       banners,
+      initialProducts,
     },
   };
 }) satisfies GetServerSideProps<{
   locale: string | null;
   seoData: PageSeoData;
   banners: StorefrontBanner[];
+  initialProducts: Product[];
 }>;
 
 export default function Home({
   locale,
   banners,
+  initialProducts,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
   const platform = usePlatform();
@@ -171,7 +187,7 @@ export default function Home({
   const { user } = useUserContext();
   const { categories } = useCategoryContext();
   const { searchKeyword, setSearchKeyword } = useProductContext();
-  const [products, setProducts] = useState<Product[]>([]);
+  const [products, setProducts] = useState<Product[]>(initialProducts ?? []);
   const [isLoading, setIsLoading] = useState(false);
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
@@ -214,6 +230,7 @@ export default function Home({
           minPrice: filters.minPrice,
           maxPrice: filters.maxPrice,
           sortBy: filters.sortBy,
+          locale: router.locale,
         });
         if (!mounted) return;
 

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -146,9 +146,8 @@ export const getServerSideProps: GetServerSideProps = (async (context) => {
     console.error('Failed to load promo banners:', error);
   }
 
-  // Fetch the first page of products server-side so their links are present
-  // in the raw HTML on wave one, instead of only appearing after the
-  // client-side fetch effect below (see docs/seo-todos.md #10/#368).
+  // Seed the first page server-side so product links are in the raw HTML,
+  // not just after the client fetch.
   let initialProducts: Product[] = [];
   try {
     initialProducts = await fetchProducts({

--- a/src/pages/lib/apis.ts
+++ b/src/pages/lib/apis.ts
@@ -22,6 +22,7 @@ export const fetchProducts = async ({
   productId,
   productSlug,
   page,
+  locale,
 }: {
   categoryIds?: string[];
   brandIds?: string[];
@@ -33,6 +34,12 @@ export const fetchProducts = async ({
   productId?: string;
   productSlug?: string;
   page?: number;
+  /**
+   * When set, the API strips names/descriptions down to this locale.
+   * Leave unset for admin flows that need the raw multi-locale JSON
+   * (e.g. AddEditProductDialog pre-filling all language fields).
+   */
+  locale?: string;
 }): Promise<ExtendedProduct[]> => {
   let url = `${BASE_URL}/api/product?page=${page || 1}`;
 
@@ -59,6 +66,7 @@ export const fetchProducts = async ({
   appendParam('productSlug', productSlug);
   appendParam('searchKeyword', searchKeyword);
   appendParam('sortBy', sortBy);
+  appendParam('locale', locale);
 
   const { success, data, message }: ResponseApi<ExtendedProduct[]> = await (
     await fetch(url)

--- a/src/pages/lib/utils.ts
+++ b/src/pages/lib/utils.ts
@@ -224,6 +224,46 @@ export const parseName = (name: string, locale: string): string => {
   }
 };
 
+// Replaces a product's `name`/`description` (raw multi-locale JSON) with the
+// single active-locale string. parseName's plain-string fallback makes this
+// safe to call more than once.
+export const sanitizeProductLocale = <
+  T extends { name: string; description: string | null },
+>(
+  product: T,
+  locale: string,
+): T => ({
+  ...product,
+  name: parseName(product.name, locale),
+  description: parseName(product.description ?? '{}', locale) ?? null,
+});
+
+// List variant of sanitizeProductLocale (used when serving/seeding product
+// grids).
+export const sanitizeProductsLocale = <
+  T extends { name: string; description: string | null },
+>(
+  products: T[],
+  locale: string,
+): T[] => products.map((product) => sanitizeProductLocale(product, locale));
+
+// Recursively replaces `name` (raw multi-locale JSON) with the single
+// active-locale string on a category, all of its successorCategories, and any
+// included products, so only one locale's data reaches the client.
+export const sanitizeCategoryLocale = <T extends ExtendedCategory>(
+  category: T,
+  locale: string,
+): T => ({
+  ...category,
+  name: parseName(category.name, locale),
+  successorCategories: category.successorCategories?.map((sub) =>
+    sanitizeCategoryLocale(sub, locale),
+  ),
+  products: category.products
+    ? sanitizeProductsLocale(category.products, locale)
+    : category.products,
+});
+
 export const addEditCategory = async ({
   type,
   formJson,

--- a/src/pages/product-category/[categorySlug].page.tsx
+++ b/src/pages/product-category/[categorySlug].page.tsx
@@ -92,9 +92,8 @@ export const getStaticProps: GetStaticProps = async ({
       categoryPath = buildCategoryPath(categoryData.id, allCategories);
     }
 
-    // Fetch the first page of products server-side so the grid's links are
-    // present in the raw HTML on wave one, instead of only appearing after
-    // the client-side fetch in ProductGridContent (see docs/seo-todos.md #10).
+    // Seed the first page server-side so product links are in the raw HTML,
+    // not just after the client fetch.
     let initialProducts: ExtendedProduct[] = [];
     try {
       initialProducts = await fetchProducts({

--- a/src/pages/product-category/[categorySlug].page.tsx
+++ b/src/pages/product-category/[categorySlug].page.tsx
@@ -1,5 +1,6 @@
 import BASE_URL from '@/lib/ApiEndpoints';
 import ProductGridContent from '@/pages/components/ProductGridContent';
+import { fetchProducts } from '@/pages/lib/apis';
 import { buildCategoryPath } from '@/pages/lib/categoryPathUtils';
 import { LOCALE_TO_OG_LOCALE } from '@/pages/lib/constants';
 import {
@@ -10,7 +11,11 @@ import {
   getCanonicalUrl,
 } from '@/pages/lib/seo';
 import { getAbsoluteCategoryMediaUrl } from '@/pages/lib/mediaUrls';
-import { ExtendedCategory, ResponseApi } from '@/pages/lib/types';
+import {
+  ExtendedCategory,
+  ExtendedProduct,
+  ResponseApi,
+} from '@/pages/lib/types';
 import { parseName } from '@/pages/lib/utils';
 import { GetStaticPaths, GetStaticProps } from 'next';
 
@@ -66,7 +71,9 @@ export const getStaticProps: GetStaticProps = async ({
   try {
     const { success, data: categoryData }: ResponseApi<ExtendedCategory> =
       await (
-        await fetch(`${BASE_URL}/api/category?categorySlug=${categorySlug}`)
+        await fetch(
+          `${BASE_URL}/api/category?categorySlug=${categorySlug}&locale=${locale}`,
+        )
       ).json();
 
     if (!success || !categoryData) {
@@ -77,12 +84,29 @@ export const getStaticProps: GetStaticProps = async ({
       success: allSuccess,
       data: allCategories,
     }: ResponseApi<ExtendedCategory[]> = await (
-      await fetch(`${BASE_URL}/api/category`)
+      await fetch(`${BASE_URL}/api/category?locale=${locale}`)
     ).json();
 
     let categoryPath: ExtendedCategory[] = [];
     if (allSuccess && allCategories && categoryData) {
       categoryPath = buildCategoryPath(categoryData.id, allCategories);
+    }
+
+    // Fetch the first page of products server-side so the grid's links are
+    // present in the raw HTML on wave one, instead of only appearing after
+    // the client-side fetch in ProductGridContent (see docs/seo-todos.md #10).
+    let initialProducts: ExtendedProduct[] = [];
+    try {
+      initialProducts = await fetchProducts({
+        categoryIds: [categoryData.id],
+        page: 1,
+        locale,
+      });
+    } catch (productsError) {
+      console.error(
+        'Error fetching initial products during build:',
+        productsError,
+      );
     }
 
     let messages = null;
@@ -150,6 +174,7 @@ export const getStaticProps: GetStaticProps = async ({
       props: {
         category: categoryData,
         categoryPath,
+        initialProducts,
         messages,
         seoData,
       },
@@ -164,17 +189,20 @@ export const getStaticProps: GetStaticProps = async ({
 interface ProductCategoryPageProps {
   category: ExtendedCategory;
   categoryPath: ExtendedCategory[];
+  initialProducts: ExtendedProduct[];
 }
 
 export default function ProductCategoryPage({
   category,
   categoryPath,
+  initialProducts,
 }: ProductCategoryPageProps) {
   return (
     <ProductGridContent
       landingCategoryId={category?.id}
       category={category}
       categoryPath={categoryPath}
+      initialProducts={initialProducts}
     />
   );
 }

--- a/src/pages/product/[slug].page.tsx
+++ b/src/pages/product/[slug].page.tsx
@@ -464,32 +464,41 @@ export default function Product({ product: initialProduct }: ProductPageProps) {
                 // Page props only carry the active locale's name/description
                 // (see getStaticProps sanitization); fetch the raw multi-locale
                 // record on demand so the edit form can still show all locales.
-                const rawResults = await fetchProducts({
-                  productId: initialProduct.id,
-                });
-                const rawProduct = rawResults?.[0];
-                if (rawProduct == null) return;
-                setAddEditProductDialog({
-                  open: true,
-                  id: rawProduct.id,
-                  description: rawProduct.description,
-                  dialogType: 'edit',
-                  imageUrls: rawProduct.imgUrls,
-                  name: rawProduct.name,
-                  price: (() => {
-                    const priceMatch =
-                      rawProduct.price?.match(squareBracketRegex);
-                    if (priceMatch != null) {
-                      return priceMatch[0]; // rawProduct.price = [id]{value}
-                    }
-                    return rawProduct.price;
-                  })(),
-                  tags: rawProduct.tags,
-                  videoUrls: rawProduct.videoUrls,
-                  brandId: rawProduct.brandId,
-                  categoryId: rawProduct.categoryId,
-                  isOutOfStock: rawProduct.isOutOfStock,
-                });
+                try {
+                  const rawResults = await fetchProducts({
+                    productId: initialProduct.id,
+                  });
+                  const rawProduct = rawResults?.[0];
+                  if (rawProduct == null) return;
+                  setAddEditProductDialog({
+                    open: true,
+                    id: rawProduct.id,
+                    description: rawProduct.description,
+                    dialogType: 'edit',
+                    imageUrls: rawProduct.imgUrls,
+                    name: rawProduct.name,
+                    price: (() => {
+                      const priceMatch =
+                        rawProduct.price?.match(squareBracketRegex);
+                      if (priceMatch != null) {
+                        return priceMatch[0]; // rawProduct.price = [id]{value}
+                      }
+                      return rawProduct.price;
+                    })(),
+                    tags: rawProduct.tags,
+                    videoUrls: rawProduct.videoUrls,
+                    brandId: rawProduct.brandId,
+                    categoryId: rawProduct.categoryId,
+                    isOutOfStock: rawProduct.isOutOfStock,
+                  });
+                } catch (error) {
+                  console.error(error);
+                  setSnackbarOpen(true);
+                  setSnackbarMessage({
+                    message: 'serverError',
+                    severity: 'error',
+                  });
+                }
               }}
             >
               <EditIcon color="primary" fontSize="medium" />

--- a/src/pages/product/[slug].page.tsx
+++ b/src/pages/product/[slug].page.tsx
@@ -461,9 +461,8 @@ export default function Product({ product: initialProduct }: ProductPageProps) {
             <IconButton
               onClick={async () => {
                 if (initialProduct == null) return;
-                // Page props only carry the active locale's name/description
-                // (see getStaticProps sanitization); fetch the raw multi-locale
-                // record on demand so the edit form can still show all locales.
+                // Page props are single-locale; re-fetch the raw record so the
+                // edit form can show all languages.
                 try {
                   const rawResults = await fetchProducts({
                     productId: initialProduct.id,

--- a/src/pages/product/[slug].page.tsx
+++ b/src/pages/product/[slug].page.tsx
@@ -126,7 +126,7 @@ export const getStaticProps: GetStaticProps = async ({
     }
 
     // Fetch the specific product at build time
-    const products = await fetchProducts({ productSlug });
+    const products = await fetchProducts({ productSlug, locale });
     const product = products && products.length > 0 ? products[0] : null;
 
     if (!product) {
@@ -257,9 +257,6 @@ export default function Product({ product: initialProduct }: ProductPageProps) {
   const { setProducts } = useProductContext();
   const { categories: allCategories, selectedCategoryId } =
     useCategoryContext();
-  const [addEditProductDialog, setAddEditProductDialog] =
-    useState<AddEditProductProps>({ open: false, imageUrls: [] });
-  const [description, setDescription] = useState<{ [key: string]: string[] }>();
   const [categoryPath, setCategoryPath] = useState<ExtendedCategory[]>([]);
   const { network } = useNetworkContext();
 
@@ -408,9 +405,12 @@ export default function Product({ product: initialProduct }: ProductPageProps) {
     setCategoryPath(path);
   }, [product?.categoryId, allCategories]);
 
-  useEffect(() => {
+  const [addEditProductDialog, setAddEditProductDialog] =
+    useState<AddEditProductProps>({ open: false, imageUrls: [] });
+
+  const description = useMemo(() => {
     const desc = parseName(product?.description ?? '{}', router.locale ?? 'tk');
-    if (desc == null || desc === '') return;
+    if (desc == null || desc === '') return undefined;
 
     const paragraphs = desc.split(/\[(.*?)\]/).filter(Boolean);
     const result: { [key: string]: string } = {};
@@ -427,7 +427,7 @@ export default function Product({ product: initialProduct }: ProductPageProps) {
       descObj[key] = result[key].split('\n').filter(Boolean);
     });
 
-    setDescription(descObj);
+    return descObj;
   }, [product?.description, router.locale]);
 
   useEffect(() => {
@@ -459,28 +459,36 @@ export default function Product({ product: initialProduct }: ProductPageProps) {
         {['SUPERUSER', 'ADMIN'].includes(user?.grade) && (
           <Box>
             <IconButton
-              onClick={() => {
+              onClick={async () => {
                 if (initialProduct == null) return;
+                // Page props only carry the active locale's name/description
+                // (see getStaticProps sanitization); fetch the raw multi-locale
+                // record on demand so the edit form can still show all locales.
+                const rawResults = await fetchProducts({
+                  productId: initialProduct.id,
+                });
+                const rawProduct = rawResults?.[0];
+                if (rawProduct == null) return;
                 setAddEditProductDialog({
                   open: true,
-                  id: initialProduct.id,
-                  description: initialProduct.description,
+                  id: rawProduct.id,
+                  description: rawProduct.description,
                   dialogType: 'edit',
-                  imageUrls: initialProduct.imgUrls,
-                  name: initialProduct.name,
+                  imageUrls: rawProduct.imgUrls,
+                  name: rawProduct.name,
                   price: (() => {
                     const priceMatch =
-                      initialProduct.price?.match(squareBracketRegex);
+                      rawProduct.price?.match(squareBracketRegex);
                     if (priceMatch != null) {
-                      return priceMatch[0]; // initialProduct.price = [id]{value}
+                      return priceMatch[0]; // rawProduct.price = [id]{value}
                     }
-                    return initialProduct.price;
+                    return rawProduct.price;
                   })(),
-                  tags: initialProduct.tags,
-                  videoUrls: initialProduct.videoUrls,
-                  brandId: initialProduct.brandId,
-                  categoryId: initialProduct.categoryId,
-                  isOutOfStock: initialProduct.isOutOfStock,
+                  tags: rawProduct.tags,
+                  videoUrls: rawProduct.videoUrls,
+                  brandId: rawProduct.brandId,
+                  categoryId: rawProduct.categoryId,
+                  isOutOfStock: rawProduct.isOutOfStock,
                 });
               }}
             >


### PR DESCRIPTION
Second PR in the stack. **Base branch: `seo/crawl-media-and-product-ssr`** (PR 1). Review/merge PR 1 first.

## Changes
- **Opt-in `?locale=` param** on `GET /api/product` and `GET /api/category` — strip the multi-locale JSON blobs (`Product.name`, `Product.description`, `Category.name`) to a single locale when a valid `?locale=` is passed; return the raw blob when absent/invalid (admin edit flows rely on the raw blob). Single stripping point covers SSR props and client AJAX.
- **SSR catalog pages fetch already-localized** (product, category, product-category, index) and drop their per-page sanitize calls — only the active locale is serialized into `__NEXT_DATA__` (~69% smaller list payload in local testing).
- **Product-category grid SSR** — narrow the `if (!router.isReady) return null` guard to `!landingCategoryId && !router.isReady`, so landing pages (category resolved server-side from the slug) render their seeded `initialProducts` grid during SSR, while the query-driven `/product` browse page still waits for the client. 

## Verified
- `?locale=en` → plain strings; no param → raw blob; `?locale=xx` → raw (ignored).
- product-category PLP body: 0 → seeded grid, 0 skeletons, product names in raw HTML.

Closes #369 