### PR TITLE
SEO: render product & category cards as crawlable <a href> links

### DIFF
--- a/src/pages/category/[slug].page.tsx
+++ b/src/pages/category/[slug].page.tsx
@@ -292,9 +292,9 @@ export default function CategoryPage({
           <CategoryCard
             name=""
             initialImgUrl={ALL_PRODUCTS_CATEGORY_CARD}
+            href={`/product-category/${category.slug}`}
             onClick={() => {
               setProducts([]);
-              router.push(`/product-category/${category.slug}`);
             }}
           />
           {/* Subcategories */}
@@ -305,9 +305,7 @@ export default function CategoryPage({
                 name={name}
                 initialImgUrl={imgUrl ?? undefined}
                 key={id}
-                onClick={() => {
-                  router.push(`/category/${slug}`);
-                }}
+                href={`/category/${slug}`}
               />
             );
           })}

--- a/src/pages/category/index.page.tsx
+++ b/src/pages/category/index.page.tsx
@@ -11,7 +11,6 @@ import { interClassname } from '@/styles/theme';
 import { Box, Typography } from '@mui/material';
 import { GetServerSideProps } from 'next';
 import { useTranslations } from 'next-intl';
-import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
@@ -41,7 +40,6 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 };
 
 export default function CategoriesPage() {
-  const router = useRouter();
   const platform = usePlatform();
   const { categories: allCategories, setCategories } = useCategoryContext();
   const { setProducts } = useProductContext();
@@ -84,21 +82,20 @@ export default function CategoriesPage() {
         <Box className={categoryPageClasses.card[platform]}>
           {allCategories?.map((category) => {
             const { imgUrl, name, id, slug, successorCategories } = category;
+            const isLeaf =
+              successorCategories == null || successorCategories.length === 0;
+            const href = isLeaf
+              ? `/product-category/${slug}`
+              : `/category/${slug}`;
             return (
               <CategoryCard
                 name={name}
                 initialImgUrl={imgUrl ?? undefined}
                 key={id}
+                href={href}
                 onClick={() => {
-                  // Navigate to category page or products
-                  if (
-                    successorCategories == null ||
-                    successorCategories.length === 0
-                  ) {
+                  if (isLeaf) {
                     setProducts([]);
-                    router.push(`/product-category/${slug}`);
-                  } else {
-                    router.push(`/category/${slug}`);
                   }
                 }}
               />

--- a/src/pages/components/CategoryCard.tsx
+++ b/src/pages/components/CategoryCard.tsx
@@ -12,18 +12,21 @@ import Card from '@mui/material/Card';
 import CardMedia from '@mui/material/CardMedia';
 import Typography from '@mui/material/Typography';
 import { useTranslations } from 'next-intl';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useMemo } from 'react';
 
 interface CategoryCardProps {
   name: string;
   initialImgUrl?: string;
-  onClick: () => void;
+  href?: string;
+  onClick?: () => void;
 }
 
 export default function CategoryCard({
   initialImgUrl,
   name,
+  href,
   onClick,
 }: CategoryCardProps) {
   const router = useRouter();
@@ -42,42 +45,59 @@ export default function CategoryCard({
     return getCategoryMediaUrl(initialImgUrl) ?? PRODUCT_IMAGE_FALLBACK;
   }, [initialImgUrl]);
 
+  const content =
+    initialImgUrl === ALL_PRODUCTS_CATEGORY_CARD ? (
+      <Box className={categoryCardClasses.boxes.allP}>
+        <Typography
+          className={`${categoryCardClasses.typography[platform]} ${interClassname.className}`}
+        >
+          {t('allProducts')}
+        </Typography>
+      </Box>
+    ) : (
+      <Box className={categoryCardClasses.boxes.cardMedia[platform]}>
+        <Typography
+          className={`${categoryCardClasses.typography2[platform]} ${interClassname.className}`}
+        >
+          {parseName(name, router.locale ?? 'tk')}
+        </Typography>
+        <CardMedia
+          component="img"
+          className={categoryCardClasses.cardMedia[platform]}
+          image={imgSrc ?? PRODUCT_IMAGE_FALLBACK}
+          alt="Xmobile"
+          loading="lazy"
+          decoding="async"
+          onError={(e) => {
+            const el = e.currentTarget;
+            el.onerror = null;
+            el.src = PRODUCT_IMAGE_FALLBACK;
+          }}
+        />
+      </Box>
+    );
+
+  if (href) {
+    return (
+      <Card
+        component={Link}
+        href={href}
+        className={categoryCardClasses.card[platform]}
+        onClick={onClick}
+        elevation={0}
+      >
+        {content}
+      </Card>
+    );
+  }
+
   return (
     <Card
       className={categoryCardClasses.card[platform]}
       onClick={onClick}
       elevation={0}
     >
-      {initialImgUrl === ALL_PRODUCTS_CATEGORY_CARD ? (
-        <Box className={categoryCardClasses.boxes.allP}>
-          <Typography
-            className={`${categoryCardClasses.typography[platform]} ${interClassname.className}`}
-          >
-            {t('allProducts')}
-          </Typography>
-        </Box>
-      ) : (
-        <Box className={categoryCardClasses.boxes.cardMedia[platform]}>
-          <Typography
-            className={`${categoryCardClasses.typography2[platform]} ${interClassname.className}`}
-          >
-            {parseName(name, router.locale ?? 'tk')}
-          </Typography>
-          <CardMedia
-            component="img"
-            className={categoryCardClasses.cardMedia[platform]}
-            image={imgSrc ?? PRODUCT_IMAGE_FALLBACK}
-            alt="Xmobile"
-            loading="lazy"
-            decoding="async"
-            onError={(e) => {
-              const el = e.currentTarget;
-              el.onerror = null;
-              el.src = PRODUCT_IMAGE_FALLBACK;
-            }}
-          />
-        </Box>
-      )}
+      {content}
     </Card>
   );
 }

--- a/src/pages/components/ProductCard.tsx
+++ b/src/pages/components/ProductCard.tsx
@@ -27,6 +27,7 @@ import {
 import CircularProgress from '@mui/material/CircularProgress';
 import { Product } from '@prisma/client';
 import { useTranslations } from 'next-intl';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { lazy, useEffect, useMemo, useState } from 'react';
 
@@ -78,62 +79,62 @@ export default function ProductCard({
   return (
     <Card className={productCardClasses.card[platform]} elevation={0}>
       {product != null ? (
-        <Box
-          className={productCardClasses.boxes.main}
-          onClick={() => {
-            setSelectedProduct(initialProduct);
-            router.push(`/product/${product.slug}`);
-          }}
-        >
-          {cardImageSrc != null && (
-            <Box className={productCardClasses.boxes.img[platform]}>
-              <CardMedia
-                component="img"
-                image={cardImageSrc}
-                alt={product?.name}
-                className={`${productCardClasses.cardMedia[platform]} transition-all duration-200${product.isOutOfStock ? ' grayscale opacity-60' : ''}`}
-                loading="lazy"
-                decoding="async"
-                onError={(e) => {
-                  const el = e.currentTarget;
-                  el.onerror = null;
-                  el.src = PRODUCT_IMAGE_FALLBACK;
-                }}
-              />
-              {product.isOutOfStock && (
-                <Box
-                  className={`absolute top-2 left-2 bg-white/90 border border-[#e0e0e0] rounded-full ${platform === 'web' ? 'px-2.5 py-0.5' : 'px-1.5 py-0'}`}
-                >
-                  <Typography
-                    className={`font-semibold text-[#555] uppercase tracking-wider ${platform === 'web' ? 'text-[11px]' : 'text-[9px]'}`}
+        <Box className={productCardClasses.boxes.main}>
+          <Link
+            href={`/product/${product.slug}`}
+            onClick={() => setSelectedProduct(initialProduct)}
+            className="block text-inherit no-underline"
+          >
+            {cardImageSrc != null && (
+              <Box className={productCardClasses.boxes.img[platform]}>
+                <CardMedia
+                  component="img"
+                  image={cardImageSrc}
+                  alt={product?.name}
+                  className={`${productCardClasses.cardMedia[platform]} transition-all duration-200${product.isOutOfStock ? ' grayscale opacity-60' : ''}`}
+                  loading="lazy"
+                  decoding="async"
+                  onError={(e) => {
+                    const el = e.currentTarget;
+                    el.onerror = null;
+                    el.src = PRODUCT_IMAGE_FALLBACK;
+                  }}
+                />
+                {product.isOutOfStock && (
+                  <Box
+                    className={`absolute top-2 left-2 bg-white/90 border border-[#e0e0e0] rounded-full ${platform === 'web' ? 'px-2.5 py-0.5' : 'px-1.5 py-0'}`}
                   >
-                    {t('outOfStock')}
-                  </Typography>
-                </Box>
+                    <Typography
+                      className={`font-semibold text-[#555] uppercase tracking-wider ${platform === 'web' ? 'text-[11px]' : 'text-[9px]'}`}
+                    >
+                      {t('outOfStock')}
+                    </Typography>
+                  </Box>
+                )}
+              </Box>
+            )}
+            <Box className={productCardClasses.boxes.detail[platform]}>
+              <Typography
+                className={`${interClassname.className} ${productCardClasses.typo[platform]}`}
+              >
+                {parseName(product.name, router.locale ?? 'tk')}
+              </Typography>
+              {product?.price?.includes('[') ? (
+                <CircularProgress
+                  className={productCardClasses.circProgress[platform]}
+                />
+              ) : (
+                <Typography
+                  color={colors.mainWebMobile[platform]}
+                  className={`${interClassname.className} ${productCardClasses.typo2[platform]}`}
+                >
+                  {product?.price} {t('manat')}
+                </Typography>
               )}
             </Box>
-          )}
-          <Box className={productCardClasses.boxes.detail[platform]}>
-            <Typography
-              className={`${interClassname.className} ${productCardClasses.typo[platform]}`}
-            >
-              {parseName(product.name, router.locale ?? 'tk')}
-            </Typography>
-            {product?.price?.includes('[') ? (
-              <CircularProgress
-                className={productCardClasses.circProgress[platform]}
-              />
-            ) : (
-              <Typography
-                color={colors.mainWebMobile[platform]}
-                className={`${interClassname.className} ${productCardClasses.typo2[platform]}`}
-              >
-                {product?.price} {t('manat')}
-              </Typography>
-            )}
-          </Box>
+          </Link>
           {cartProps.cartAction === 'delete' && !product.isOutOfStock && (
-            <Box onClick={(e) => e.stopPropagation()}>
+            <Box>
               <AddToCart
                 productId={product.id}
                 cartAction={cartProps?.cartAction}


### PR DESCRIPTION
Third PR in the stack. **Base branch: `seo/single-locale-catalog`** (PR 2). Review/merge PRs 1 and 2 first.

## Changes
- **Product cards → `<a href>`** — `ProductCard` wraps its body in `next/link`, emitting a real `<a href="/product/{slug}">` in SSR HTML while keeping client-side navigation and the `setSelectedProduct` prefetch. `AddToCart` moves to a sibling of the link (an `<a>` may not contain a `<button>`).
- **Category cards → `<a href>`** — `CategoryCard` gains an optional `href` and renders as `next/link` when set. On the SSR'd `/category/[slug]` page this puts the All-Products link to `/product-category/{slug}` + subcategory links into raw HTML.

## Verified
- product-category PLP body: **0 → 20** real product anchors.
- `/category/phones`: All-Products anchor + 7 subcategory anchors in raw HTML.

## Note
The `/category` **index** page sources its category tree from `CategoryContext` (client fetch), so its card anchors appear only after hydration (page is noindex). Follow-up noted in `docs/seo-todos.md`.