### PR TITLE
Chat Improvements

### DIFF
--- a/src/pages/lib/WebSocketContext.tsx
+++ b/src/pages/lib/WebSocketContext.tsx
@@ -96,15 +96,16 @@ export const WebSocketContextProvider = ({
     const wsUrl = `${wsBase}/ws/?accessToken=${accessToken}`;
 
     try {
-      wsRef.current = new WebSocket(wsUrl);
+      const socket = new WebSocket(wsUrl);
+      wsRef.current = socket;
 
-      wsRef.current.onopen = () => {
+      socket.onopen = () => {
         console.log('WebSocket connected');
         setIsConnected(true);
         reconnectAttemptsRef.current = 0; // Reset on successful connection
       };
 
-      wsRef.current.onmessage = (event) => {
+      socket.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data);
           notifySubscribers(data);
@@ -113,11 +114,15 @@ export const WebSocketContextProvider = ({
         }
       };
 
-      wsRef.current.onerror = (error) => {
+      socket.onerror = (error) => {
         console.error('WebSocket error:', error);
       };
 
-      wsRef.current.onclose = (event) => {
+      socket.onclose = (event) => {
+        // This socket has already been replaced (e.g. user switched accounts) -
+        // its stale closure must not reconnect with an outdated token.
+        if (wsRef.current !== socket) return;
+
         console.log('WebSocket disconnected', event.code, event.reason);
         setIsConnected(false);
 

--- a/src/ws-server/index.ts
+++ b/src/ws-server/index.ts
@@ -252,6 +252,12 @@ const handleMessage = async (
       },
     });
 
+    // Bump session's updatedAt so admin chat lists sort by last message, not session start
+    await dbClient.chatSession.update({
+      where: { id: sessionId },
+      data: { updatedAt: new Date() },
+    });
+
     // Only fetch the sender's name if they are staff (Admin/Superuser)
     let senderName: string | undefined;
     if (senderRole !== 'FREE') {

--- a/src/ws-server/index.ts
+++ b/src/ws-server/index.ts
@@ -252,12 +252,6 @@ const handleMessage = async (
       },
     });
 
-    // Bump session's updatedAt so admin chat lists sort by last message, not session start
-    await dbClient.chatSession.update({
-      where: { id: sessionId },
-      data: { updatedAt: new Date() },
-    });
-
     // Only fetch the sender's name if they are staff (Admin/Superuser)
     let senderName: string | undefined;
     if (senderRole !== 'FREE') {
@@ -290,6 +284,18 @@ const handleMessage = async (
     };
 
     broadcastToSession(connections, adminConnections, session, outgoingMessage);
+
+    // Bump session's updatedAt so admin chat lists sort by last message, not
+    // session start. Done after broadcast so a failure here can't drop the
+    // message (the send path already succeeded).
+    try {
+      await dbClient.chatSession.update({
+        where: { id: sessionId },
+        data: { updatedAt: new Date() },
+      });
+    } catch (bumpError) {
+      console.error(filepath, 'Failed to bump session updatedAt:', bumpError);
+    }
 
     // Create notifications for all participants except sender
     try {

--- a/tests/client/WebSocketContext.client.test.ts
+++ b/tests/client/WebSocketContext.client.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUseUserContext = vi.fn();
+vi.mock('@/pages/lib/UserContext', () => ({
+  useUserContext: () => mockUseUserContext(),
+}));
+
+// eslint-disable-next-line import/first
+import {
+  useWebSocketContext,
+  WebSocketContextProvider,
+} from '@/pages/lib/WebSocketContext';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let createdSockets: any[] = [];
+
+class FakeWebSocket {
+  static CONNECTING = 0;
+
+  static OPEN = 1;
+
+  static CLOSING = 2;
+
+  static CLOSED = 3;
+
+  url: string;
+
+  readyState = FakeWebSocket.CONNECTING;
+
+  onopen: (() => void) | null = null;
+
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+
+  onmessage: ((event: { data: string }) => void) | null = null;
+
+  onerror: ((event: unknown) => void) | null = null;
+
+  sentMessages: string[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+    createdSockets.push(this);
+  }
+
+  send(data: string) {
+    this.sentMessages.push(data);
+  }
+
+  close() {
+    this.readyState = FakeWebSocket.CLOSING;
+  }
+
+  // Test helpers simulating async network events
+  triggerOpen() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  triggerClose(code: number) {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.({ code, reason: '' });
+  }
+}
+
+const wrapper = ({ children }: { children: ReactNode }) =>
+  createElement(WebSocketContextProvider, null, children);
+
+describe('WebSocketContextProvider', () => {
+  beforeEach(() => {
+    createdSockets = [];
+    vi.useFakeTimers();
+    vi.stubGlobal('WebSocket', FakeWebSocket as unknown as typeof WebSocket);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('ignores a stale reconnect from a socket superseded by a user switch', () => {
+    mockUseUserContext.mockReturnValue({
+      user: { id: 'user-a' },
+      accessToken: 'token-a',
+    });
+
+    const { result, rerender } = renderHook(() => useWebSocketContext(), {
+      wrapper,
+    });
+
+    expect(createdSockets).toHaveLength(1);
+    const socketA = createdSockets[0];
+    expect(socketA.url).toContain('token-a');
+
+    act(() => {
+      socketA.triggerOpen();
+    });
+    expect(result.current.isConnected).toBe(true);
+
+    // User signs in as a different user: provider must tear down socketA
+    // and open a fresh socket authenticated with the new token.
+    mockUseUserContext.mockReturnValue({
+      user: { id: 'user-b' },
+      accessToken: 'token-b',
+    });
+    act(() => {
+      rerender();
+    });
+
+    expect(createdSockets).toHaveLength(2);
+    const socketB = createdSockets[1];
+    expect(socketB.url).toContain('token-b');
+    // socketB hasn't finished its handshake yet - this is the exact window
+    // where a stale reconnect could win the race and overwrite wsRef.
+    expect(socketB.readyState).toBe(FakeWebSocket.CONNECTING);
+
+    // socketA's close event arrives from the network before socketB opens.
+    // Its stale closure must not reconnect using user A's outdated token.
+    act(() => {
+      socketA.triggerClose(1006);
+    });
+
+    // Let the (buggy) reconnect backoff timer fire, if one was scheduled.
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(createdSockets).toHaveLength(2);
+  });
+});

--- a/tests/integration/chat.integration.test.ts
+++ b/tests/integration/chat.integration.test.ts
@@ -404,6 +404,57 @@ describe('Chat API (integration)', () => {
     await prisma.user.delete({ where: { id: su.userId } });
   });
 
+  it('GET /api/chat/session (admin) sorts by last activity, not session start time', async () => {
+    const free = await signupTestUser('chat-sort');
+    const admin = await createStaffPrincipal(prisma, UserRole.ADMIN);
+    const handler = (await import('@/pages/api/chat/session.page')).default;
+
+    // Older session, created first.
+    const older = await prisma.chatSession.create({
+      data: { status: 'ACTIVE', users: { connect: { id: free.userId } } },
+    });
+    // Newer session, created second - would sort first under naive createdAt/updatedAt-at-creation ordering.
+    const newer = await prisma.chatSession.create({
+      data: { status: 'ACTIVE', users: { connect: { id: free.userId } } },
+    });
+
+    // Simulate a new message arriving on the older session (mirrors the ws-server
+    // touching chatSession.updatedAt whenever a message is created).
+    await prisma.chatMessage.create({
+      data: {
+        sessionId: older.id,
+        senderId: free.userId,
+        senderRole: UserRole.FREE,
+        content: 'hello',
+      },
+    });
+    await prisma.chatSession.update({
+      where: { id: older.id },
+      data: { updatedAt: new Date() },
+    });
+
+    const list = createMocks({
+      method: 'GET',
+      url: '/api/chat/session',
+      headers: { authorization: `Bearer ${admin.accessToken}` },
+    });
+    await handler(
+      list.req as unknown as NextApiRequest,
+      list.res as unknown as NextApiResponse,
+    );
+    expect(list.res._getStatusCode()).toBe(200);
+    const ids = JSON.parse(list.res._getData() as string).data.map(
+      (s: { id: string }) => s.id,
+    );
+    expect(ids.indexOf(older.id)).toBeLessThan(ids.indexOf(newer.id));
+
+    await prisma.chatMessage.deleteMany({ where: { sessionId: older.id } });
+    await prisma.chatSession.deleteMany({
+      where: { id: { in: [older.id, newer.id] } },
+    });
+    await prisma.user.delete({ where: { id: admin.userId } });
+  });
+
   it('ADMIN POST session returns 403', async () => {
     const admin = await createStaffPrincipal(prisma, UserRole.ADMIN);
     const handler = (await import('@/pages/api/chat/session.page')).default;

--- a/tests/integration/chat.integration.test.ts
+++ b/tests/integration/chat.integration.test.ts
@@ -418,8 +418,9 @@ describe('Chat API (integration)', () => {
       data: { status: 'ACTIVE', users: { connect: { id: free.userId } } },
     });
 
-    // Simulate a new message arriving on the older session (mirrors the ws-server
-    // touching chatSession.updatedAt whenever a message is created).
+    // Bump the older session's updatedAt to the value the ws-server would write
+    // on a new message. This covers session.page.ts ordering only, NOT the
+    // ws-server bump itself (that write is not exercised here).
     await prisma.chatMessage.create({
       data: {
         sessionId: older.id,
@@ -446,6 +447,8 @@ describe('Chat API (integration)', () => {
     const ids = JSON.parse(list.res._getData() as string).data.map(
       (s: { id: string }) => s.id,
     );
+    expect(ids).toContain(older.id);
+    expect(ids).toContain(newer.id);
     expect(ids.indexOf(older.id)).toBeLessThan(ids.indexOf(newer.id));
 
     await prisma.chatMessage.deleteMany({ where: { sessionId: older.id } });


### PR DESCRIPTION
**Summary**

- Bump chatSession.updatedAt whenever a new message is created, so the admin chat list sorts by last activity instead of session creation time.
- Fix a WebSocket race condition: when a user switches accounts, the old socket's onclose handler could fire after a new socket was already assigned to wsRef.current, triggering a reconnect with the stale/outdated access token. Handlers now close over the specific socket instance and bail out if wsRef.current no longer points to it.
- Add integration test verifying admin chat list ordering follows last message activity, and a client test covering the stale-socket reconnect race.