### PR TITLE
Banner Loading and Splash Screen Edge Cases

### DIFF
--- a/docker/nginx-local/default.conf
+++ b/docker/nginx-local/default.conf
@@ -27,6 +27,11 @@ server {
         add_header Cache-Control "public, max-age=2592000, immutable";
     }
 
+    location ^~ /media/banner/ {
+        alias /home/ubuntu/images/banners/;
+        add_header Cache-Control "public, max-age=2592000, immutable";
+    }
+
     location / {
         return 404;
     }

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -130,7 +130,16 @@ export default function App({ Component, pageProps }: AppProps) {
       return undefined;
     }
 
-    const hasShownSplash = sessionStorage.getItem('hasShownSplash');
+    // sessionStorage throws when storage is blocked (in-app browsers like
+    // Instagram/Telegram, "block all cookies", strict privacy modes). Treat it
+    // as best-effort so a throw never leaves the splash stuck forever.
+    let hasShownSplash: string | null = null;
+    try {
+      hasShownSplash = sessionStorage.getItem('hasShownSplash');
+    } catch (error) {
+      // storage unavailable — fall through and just show the splash once
+      console.warn('Splash storage read failed:', error);
+    }
     if (hasShownSplash) {
       setIsLoading(false);
       return undefined;
@@ -138,7 +147,12 @@ export default function App({ Component, pageProps }: AppProps) {
 
     const timer = setTimeout(() => {
       setIsLoading(false);
-      sessionStorage.setItem('hasShownSplash', 'true');
+      try {
+        sessionStorage.setItem('hasShownSplash', 'true');
+      } catch (error) {
+        // best-effort; splash is already dismissed
+        console.warn('Splash storage write failed:', error);
+      }
     }, 1000);
 
     return () => clearTimeout(timer);

--- a/src/pages/product/[slug].page.tsx
+++ b/src/pages/product/[slug].page.tsx
@@ -73,14 +73,20 @@ import {
 import CircularProgress from '@mui/material/CircularProgress';
 import type { Color, Product } from '@prisma/client';
 import { GetStaticPaths, GetStaticProps } from 'next';
+import dynamic from 'next/dynamic';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { lazy, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import 'slick-carousel/slick/slick-theme.css';
 import 'slick-carousel/slick/slick.css';
 
-const AddToCart = lazy(() => import('@/pages/components/AddToCart'));
+// next/dynamic (not React.lazy) so the chunk suspends inside its own boundary.
+// A bare lazy() here has no ancestor <Suspense>, so a slow/cold chunk load
+// crashes hydration and the _app splash overlay never dismisses.
+const AddToCart = dynamic(() => import('@/pages/components/AddToCart'), {
+  loading: () => <CircularProgress />,
+});
 
 // getStaticPaths for dynamic routes
 export const getStaticPaths: GetStaticPaths = async (context) => {


### PR DESCRIPTION
**Summary**

Fixes local dev banner 404s plus two separate paths that could leave the splash/loading overlay stuck forever.

**Changes**

1. Local dev server banner path (docker/nginx-local/default.conf)
Added an nginx location block mapping /media/banner/ to /home/ubuntu/images/banners/ so banner images resolve in the local Docker environment (matching prod), with the same 30-day immutable cache header as other media.

2. Splash screen sticking when sessionStorage is blocked (src/pages/_app.page.tsx)
sessionStorage access throws in in-app browsers (Instagram, Telegram), "block all cookies" mode, and strict privacy modes. An unguarded throw during the splash logic left the loading screen stuck forever. Wrapped both the read and write in try/catch so storage is best-effort — a throw now falls through to showing the splash once and dismissing it normally.

3. Splash sticking from unguarded lazy AddToCart (src/pages/product/[slug].page.tsx)
AddToCart was loaded via React.lazy with no ancestor <Suspense>, so a slow/cold chunk load crashed hydration and the _app splash overlay never dismissed. Switched to next/dynamic, which suspends inside its own boundary and renders a CircularProgress fallback while loading.

**Impact**

- Local dev shows banners instead of 404s.
- Users on privacy-restricted / in-app browsers no longer get trapped on the splash screen.
- Product pages no longer hang on the splash when the AddToCart chunk is slow to load.