### PR TITLE
fix: chat welcome banner follow-ups

### DIFF
--- a/src/pages/components/chat/ChatWelcomeBanner.tsx
+++ b/src/pages/components/chat/ChatWelcomeBanner.tsx
@@ -1,49 +1,47 @@
+import { usePlatform } from '@/pages/lib/PlatformContext';
+import { colors } from '@/styles/theme';
+import { chatClasses } from '@/styles/classMaps/components/chat';
 import HeadsetMicOutlinedIcon from '@mui/icons-material/HeadsetMicOutlined';
-import { Box, Typography } from '@mui/material';
+import { alpha, Box, Typography } from '@mui/material';
 import { useTranslations } from 'next-intl';
 
 const ChatWelcomeBanner = () => {
   const t = useTranslations();
+  const platform = usePlatform();
+  const classes = chatClasses.chatWindow.welcomeBanner;
 
   return (
     <Box
+      className={classes.container[platform]}
       sx={{
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
-        px: 3,
-        pt: 3,
-        pb: 2,
       }}
     >
       <Box
+        className={classes.iconWrapper[platform]}
         sx={{
-          width: 48,
-          height: 48,
           borderRadius: '50%',
-          backgroundColor: 'rgba(255, 98, 76, 0.1)',
+          backgroundColor: alpha(colors.main, 0.1),
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          mb: 1.5,
         }}
       >
-        <HeadsetMicOutlinedIcon sx={{ color: '#FF624C', fontSize: 24 }} />
+        <HeadsetMicOutlinedIcon sx={{ color: colors.main, fontSize: 24 }} />
       </Box>
 
       <Typography
-        sx={{ fontSize: '13px', fontWeight: 600, color: '#1B1B1B', mb: 0.5 }}
+        className={classes.title[platform]}
+        sx={{ color: colors.blackText }}
       >
         {t('chatCustomerSupport')}
       </Typography>
 
       <Typography
-        sx={{
-          fontSize: '13px',
-          color: '#838383',
-          textAlign: 'center',
-          lineHeight: 1.5,
-        }}
+        className={classes.message[platform]}
+        sx={{ color: colors.placeholder, textAlign: 'center' }}
       >
         {t('chatWelcomeMessage')}
       </Typography>

--- a/src/pages/components/chat/ChatWindow.tsx
+++ b/src/pages/components/chat/ChatWindow.tsx
@@ -26,9 +26,11 @@ const ChatWindow = () => {
 
   const hasMore = messages.length >= CHAT_MESSAGES_PAGE_SIZE;
 
-  const isClosed = currentSession?.status === 'CLOSED';
+  const isSessionClosed = currentSession?.status === 'CLOSED';
 
   const isAdminView = user?.grade === 'ADMIN' || user?.grade === 'SUPERUSER';
+
+  const isSessionEmpty = messages.length === 0;
 
   useEffect(() => {
     const container = scrollRef.current;
@@ -94,7 +96,21 @@ const ChatWindow = () => {
             </Button>
           </Box>
         )}
-        {messages.length === 0 && <ChatWelcomeBanner />}
+        {isSessionEmpty &&
+          (isAdminView ? (
+            <Typography
+              sx={{
+                textAlign: 'center',
+                color: '#9E9E9E',
+                mt: 4,
+                fontSize: '14px',
+              }}
+            >
+              {t('chatStartConversation')}
+            </Typography>
+          ) : (
+            <ChatWelcomeBanner />
+          ))}
         {messages.length > 0 &&
           (() => {
             const elements: JSX.Element[] = [];
@@ -160,7 +176,7 @@ const ChatWindow = () => {
           })()}
       </Box>
 
-      {isClosed && (
+      {isSessionClosed && (
         <Box
           sx={{
             p: 1.5,
@@ -178,7 +194,7 @@ const ChatWindow = () => {
       )}
       <ChatInput
         onSendMessage={sendMessage}
-        disabled={!isConnected || isClosed}
+        disabled={!isConnected || isSessionClosed}
         isSending={isSendingMessage}
       />
     </Box>

--- a/src/styles/classMaps/components/chat.ts
+++ b/src/styles/classMaps/components/chat.ts
@@ -29,6 +29,24 @@ export const chatClasses = {
       web: 'py-[16px]',
       mobile: 'py-[12px]',
     },
+    welcomeBanner: {
+      container: {
+        web: 'px-[24px] pt-[24px] pb-[16px]',
+        mobile: 'px-[16px] pt-[20px] pb-[12px]',
+      },
+      iconWrapper: {
+        web: 'w-[48px] h-[48px] mb-[12px]',
+        mobile: 'w-[40px] h-[40px] mb-[10px]',
+      },
+      title: {
+        web: 'text-[14px] font-semibold mb-[4px]',
+        mobile: 'text-[13px] font-semibold mb-[4px]',
+      },
+      message: {
+        web: 'text-[14px] leading-[1.5]',
+        mobile: 'text-[13px] leading-[1.5]',
+      },
+    },
   },
 
   // Chat Bubble

--- a/tests/client/ChatWelcomeBanner.client.test.ts
+++ b/tests/client/ChatWelcomeBanner.client.test.ts
@@ -1,0 +1,20 @@
+// @vitest-environment jsdom
+
+import enMessages from '@/i18n/en.json';
+import ChatWelcomeBanner from '@/pages/components/chat/ChatWelcomeBanner';
+import { screen } from '@testing-library/react';
+import { createElement } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { renderWithProviders } from './helpers/renderWithProviders';
+
+describe('ChatWelcomeBanner', () => {
+  it('renders the support title and welcome message', () => {
+    renderWithProviders(createElement(ChatWelcomeBanner));
+
+    expect(
+      screen.getByText(enMessages.chatCustomerSupport),
+    ).toBeInTheDocument();
+    expect(screen.getByText(enMessages.chatWelcomeMessage)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
follow-ups from #379.

- **Admin view showed customer copy.** `ChatWindow` is shared by the widget and the admin dashboard, so staff opening an empty session read "How can we help you?" addressed to themselves. Staff now get the neutral `chatStartConversation` string.
- **Styling now follows the chat conventions.** Hardcoded hex → `colors` tokens; fixed sizes → `chatClasses.chatWindow.welcomeBanner` web/mobile variants, like `ChatBubble`. Visual deltas: title `#303030` (was `#1B1B1B`), web text 14px (was 13px; mobile unchanged).
- **Test** covering both strings.